### PR TITLE
refactor: OAuth2.0 API 에 referrer 값 추가

### DIFF
--- a/src/main/java/com/dobugs/yologaauthenticationapi/service/AuthService.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/service/AuthService.java
@@ -26,7 +26,9 @@ public class AuthService {
     public OAuthLinkResponse generateOAuthUrl(final OAuthRequest request) {
         final OAuthConnector oAuthConnector = selectConnector(request.provider());
         final String redirectUrl = decode(request.redirect_url());
-        final String oAuthUrl = oAuthConnector.generateOAuthUrl(redirectUrl);
+        final String referrer = decode(request.referrer());
+
+        final String oAuthUrl = oAuthConnector.generateOAuthUrl(redirectUrl, referrer);
 
         return new OAuthLinkResponse(oAuthUrl);
     }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/service/dto/request/OAuthRequest.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/service/dto/request/OAuthRequest.java
@@ -1,4 +1,4 @@
 package com.dobugs.yologaauthenticationapi.service.dto.request;
 
-public record OAuthRequest(String provider, String redirect_url) {
+public record OAuthRequest(String provider, String redirect_url, String referrer) {
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/OAuthConnector.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/OAuthConnector.java
@@ -10,7 +10,7 @@ public interface OAuthConnector {
 
     RestTemplate REST_TEMPLATE = new RestTemplate();
 
-    String generateOAuthUrl(String redirectUrl);
+    String generateOAuthUrl(String redirectUrl, String referrer);
 
     String requestAccessToken(String authorizationCode, String redirectUrl);
 

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/OAuthProvider.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/OAuthProvider.java
@@ -8,7 +8,7 @@ import org.springframework.util.MultiValueMap;
 
 public interface OAuthProvider {
 
-    String generateOAuthUrl(String redirectUrl);
+    String generateOAuthUrl(String redirectUrl, String referrer);
 
     HttpEntity<MultiValueMap<String, String>> createEntity(String authorizationCode, String redirectUrl);
 

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleConnector.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleConnector.java
@@ -20,8 +20,8 @@ public class GoogleConnector implements OAuthConnector {
     private final OAuthProvider googleProvider;
 
     @Override
-    public String generateOAuthUrl(final String redirectUrl) {
-        return googleProvider.generateOAuthUrl(redirectUrl);
+    public String generateOAuthUrl(final String redirectUrl, final String referrer) {
+        return googleProvider.generateOAuthUrl(redirectUrl, referrer);
     }
 
     @Override

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleProvider.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleProvider.java
@@ -46,8 +46,9 @@ public class GoogleProvider implements OAuthProvider {
     }
 
     @Override
-    public String generateOAuthUrl(final String redirectUrl) {
+    public String generateOAuthUrl(final String redirectUrl, final String referrer) {
         params.put("redirect_uri", redirectUrl);
+        params.put("referrer", referrer);
         return authUrl + "?" + concatParams(params);
     }
 

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoConnector.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoConnector.java
@@ -20,8 +20,8 @@ public class KakaoConnector implements OAuthConnector {
     private final OAuthProvider kakaoProvider;
 
     @Override
-    public String generateOAuthUrl(final String redirectUrl) {
-        return kakaoProvider.generateOAuthUrl(redirectUrl);
+    public String generateOAuthUrl(final String redirectUrl, final String referrer) {
+        return kakaoProvider.generateOAuthUrl(redirectUrl, referrer);
     }
 
     @Override

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoProvider.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoProvider.java
@@ -40,8 +40,9 @@ public class KakaoProvider implements OAuthProvider {
     }
 
     @Override
-    public String generateOAuthUrl(final String redirectUrl) {
+    public String generateOAuthUrl(final String redirectUrl, final String referrer) {
         params.put("redirect_uri", redirectUrl);
+        params.put("referrer", referrer);
         return authUrl + "?" + concatParams(params);
     }
 

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/AuthServiceTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/AuthServiceTest.java
@@ -18,7 +18,7 @@ import com.dobugs.yologaauthenticationapi.support.OAuthConnector;
 @DisplayName("Auth 서비스 테스트")
 class AuthServiceTest {
 
-    private static final String YOLOGA_URL = "https://yologa.dobugs.co.kr";
+    private static final String REDIRECT_URL = "https://yologa.dobugs.co.kr";
     private static final String REFERRER_URL = "https://yologa.dobugs.co.kr";
 
     private AuthService authService;
@@ -37,29 +37,29 @@ class AuthServiceTest {
         @Test
         void generateGoogleOAuthUrl() {
             final String provider = "google";
-            final OAuthRequest request = new OAuthRequest(provider, YOLOGA_URL, REFERRER_URL);
+            final OAuthRequest request = new OAuthRequest(provider, REDIRECT_URL, REFERRER_URL);
 
             final OAuthLinkResponse response = authService.generateOAuthUrl(request);
 
-            assertThat(response.oauthLoginLink()).contains(YOLOGA_URL);
+            assertThat(response.oauthLoginLink()).contains(REDIRECT_URL);
         }
 
         @DisplayName("카카오 OAuth URL 을 생성한다")
         @Test
         void generateKakaoOAuthUrl() {
             final String provider = "kakao";
-            final OAuthRequest request = new OAuthRequest(provider, YOLOGA_URL, REFERRER_URL);
+            final OAuthRequest request = new OAuthRequest(provider, REDIRECT_URL, REFERRER_URL);
 
             final OAuthLinkResponse response = authService.generateOAuthUrl(request);
 
-            assertThat(response.oauthLoginLink()).contains(YOLOGA_URL);
+            assertThat(response.oauthLoginLink()).contains(REDIRECT_URL);
         }
 
         @DisplayName("존재하지 않는 provider 를 요청할 경우 예외가 발생한다")
         @Test
         void notExistProvider() {
             final String provider = "notExistProvider";
-            final OAuthRequest request = new OAuthRequest(provider, YOLOGA_URL, REFERRER_URL);
+            final OAuthRequest request = new OAuthRequest(provider, REDIRECT_URL, REFERRER_URL);
 
             assertThatThrownBy(() -> authService.generateOAuthUrl(request))
                 .isInstanceOf(IllegalArgumentException.class)

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/AuthServiceTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/AuthServiceTest.java
@@ -19,6 +19,7 @@ import com.dobugs.yologaauthenticationapi.support.OAuthConnector;
 class AuthServiceTest {
 
     private static final String YOLOGA_URL = "http://yologa.dobugs.co.kr";
+    private static final String REFERRER_URL = "http://yologa.dobugs.co.kr";
 
     private AuthService authService;
 
@@ -36,7 +37,7 @@ class AuthServiceTest {
         @Test
         void generateGoogleOAuthUrl() {
             final String provider = "google";
-            final OAuthRequest request = new OAuthRequest(provider, YOLOGA_URL);
+            final OAuthRequest request = new OAuthRequest(provider, YOLOGA_URL, REFERRER_URL);
 
             final OAuthLinkResponse response = authService.generateOAuthUrl(request);
 
@@ -47,7 +48,7 @@ class AuthServiceTest {
         @Test
         void generateKakaoOAuthUrl() {
             final String provider = "kakao";
-            final OAuthRequest request = new OAuthRequest(provider, YOLOGA_URL);
+            final OAuthRequest request = new OAuthRequest(provider, YOLOGA_URL, REFERRER_URL);
 
             final OAuthLinkResponse response = authService.generateOAuthUrl(request);
 
@@ -58,7 +59,7 @@ class AuthServiceTest {
         @Test
         void notExistProvider() {
             final String provider = "notExistProvider";
-            final OAuthRequest request = new OAuthRequest(provider, YOLOGA_URL);
+            final OAuthRequest request = new OAuthRequest(provider, YOLOGA_URL, REFERRER_URL);
 
             assertThatThrownBy(() -> authService.generateOAuthUrl(request))
                 .isInstanceOf(IllegalArgumentException.class)

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/AuthServiceTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/AuthServiceTest.java
@@ -18,8 +18,8 @@ import com.dobugs.yologaauthenticationapi.support.OAuthConnector;
 @DisplayName("Auth 서비스 테스트")
 class AuthServiceTest {
 
-    private static final String YOLOGA_URL = "http://yologa.dobugs.co.kr";
-    private static final String REFERRER_URL = "http://yologa.dobugs.co.kr";
+    private static final String YOLOGA_URL = "https://yologa.dobugs.co.kr";
+    private static final String REFERRER_URL = "https://yologa.dobugs.co.kr";
 
     private AuthService authService;
 

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/FakeConnector.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/FakeConnector.java
@@ -8,8 +8,8 @@ public class FakeConnector implements OAuthConnector {
     private final OAuthProvider provider = new FakeProvider();
 
     @Override
-    public String generateOAuthUrl(final String redirectUrl) {
-        return provider.generateOAuthUrl(redirectUrl);
+    public String generateOAuthUrl(final String redirectUrl, final String referrer) {
+        return provider.generateOAuthUrl(redirectUrl, referrer);
     }
 
     @Override

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/FakeProvider.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/FakeProvider.java
@@ -22,8 +22,9 @@ public class FakeProvider implements OAuthProvider {
     }
 
     @Override
-    public String generateOAuthUrl(final String redirectUrl) {
+    public String generateOAuthUrl(final String redirectUrl, final String referrer) {
         params.put("redirect_uri", redirectUrl);
+        params.put("referrer", referrer);
         return AUTH_URL + "?" + concatParams();
     }
 


### PR DESCRIPTION
## *관련 작업 티켓

- https://dobugs.atlassian.net/browse/YOL-110

## *작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- OAuth2.0 로그인을 위해서는 총 두 개의 API 를 호출해야 합니다.
- 서비스 확장을 위해 프론트 인증 서버를 분리함에 따라 인증 서버가 두번째 API 호출 후 Redirect 할 URL 을 알 수가 없습니다.
- 프론트 인증 서버에서 첫번째 API 에서 요청했던 Redirect URL 을 알기 위해 OAuth API 에 `referrer` 값을 추가하였습니다.

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)
