### PR TITLE
feat: OAuth2.0 로그인 시 토큰 응답

### DIFF
--- a/src/docs/asciidoc/auth.adoc
+++ b/src/docs/asciidoc/auth.adoc
@@ -5,8 +5,14 @@
 :toc: left
 :toclevels: 2
 
-== OAuth2.0 로그인 요청
+== OAuth2.0 로그인 URL 요청
 Request
 include::{snippets}/auth/generate-OAuth-url/http-request.adoc[]
 Response
 include::{snippets}/auth/generate-OAuth-url/http-response.adoc[]
+
+== OAuth2.0 로그인 토큰 요청
+Request
+include::{snippets}/auth/login/http-request.adoc[]
+Response
+include::{snippets}/auth/login/http-response.adoc[]

--- a/src/main/java/com/dobugs/yologaauthenticationapi/exception/ControllerAdvice.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/exception/ControllerAdvice.java
@@ -1,0 +1,23 @@
+package com.dobugs.yologaauthenticationapi.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.dobugs.yologaauthenticationapi.exception.dto.response.ExceptionResponse;
+
+@RestControllerAdvice
+public class ControllerAdvice {
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ExceptionResponse> handleInternalServerError(Exception e) {
+        final ExceptionResponse response = ExceptionResponse.from(e.getMessage());
+        return ResponseEntity.internalServerError().body(response);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ExceptionResponse> handleBadRequest(Exception e) {
+        final ExceptionResponse response = ExceptionResponse.from(e.getMessage());
+        return ResponseEntity.badRequest().body(response);
+    }
+}

--- a/src/main/java/com/dobugs/yologaauthenticationapi/exception/dto/response/ExceptionResponse.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/exception/dto/response/ExceptionResponse.java
@@ -1,0 +1,16 @@
+package com.dobugs.yologaauthenticationapi.exception.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class ExceptionResponse {
+
+    private final String message;
+
+    public static ExceptionResponse from(final String message) {
+        return new ExceptionResponse(message);
+    }
+}

--- a/src/main/java/com/dobugs/yologaauthenticationapi/service/AuthService.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/service/AuthService.java
@@ -12,6 +12,7 @@ import com.dobugs.yologaauthenticationapi.service.dto.request.OAuthRequest;
 import com.dobugs.yologaauthenticationapi.service.dto.response.OAuthLinkResponse;
 import com.dobugs.yologaauthenticationapi.service.dto.response.OAuthTokenResponse;
 import com.dobugs.yologaauthenticationapi.support.OAuthConnector;
+import com.dobugs.yologaauthenticationapi.support.dto.response.TokenResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -37,9 +38,10 @@ public class AuthService {
     public OAuthTokenResponse login(final OAuthRequest request, final OAuthCodeRequest codeRequest) {
         final OAuthConnector oAuthConnector = selectConnector(request.provider());
         final String redirectUrl = decode(request.redirect_url());
+        final String authorizationCode = decode(codeRequest.authorizationCode());
 
-        final String accessToken = oAuthConnector.requestAccessToken(codeRequest.authorizationCode(), redirectUrl);
-        return null;
+        final TokenResponse tokenResponse = oAuthConnector.requestAccessToken(authorizationCode, redirectUrl);
+        return new OAuthTokenResponse(tokenResponse.accessToken(), tokenResponse.refreshToken());
     }
 
     private OAuthConnector selectConnector(final String provider) {

--- a/src/main/java/com/dobugs/yologaauthenticationapi/service/AuthService.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/service/AuthService.java
@@ -40,7 +40,7 @@ public class AuthService {
         final String redirectUrl = decode(request.redirect_url());
         final String authorizationCode = decode(codeRequest.authorizationCode());
 
-        final TokenResponse tokenResponse = oAuthConnector.requestAccessToken(authorizationCode, redirectUrl);
+        final TokenResponse tokenResponse = oAuthConnector.requestToken(authorizationCode, redirectUrl);
         return new OAuthTokenResponse(tokenResponse.accessToken(), tokenResponse.refreshToken());
     }
 

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/OAuthConnector.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/OAuthConnector.java
@@ -10,5 +10,5 @@ public interface OAuthConnector {
 
     String generateOAuthUrl(String redirectUrl, String referrer);
 
-    TokenResponse requestAccessToken(String authorizationCode, String redirectUrl);
+    TokenResponse requestToken(String authorizationCode, String redirectUrl);
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/OAuthConnector.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/OAuthConnector.java
@@ -1,7 +1,5 @@
 package com.dobugs.yologaauthenticationapi.support;
 
-import org.springframework.http.HttpStatusCode;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
 import com.dobugs.yologaauthenticationapi.support.dto.response.TokenResponse;
@@ -12,12 +10,5 @@ public interface OAuthConnector {
 
     String generateOAuthUrl(String redirectUrl, String referrer);
 
-    String requestAccessToken(String authorizationCode, String redirectUrl);
-
-    default void validateConnectionResponseIsSuccess(final ResponseEntity<TokenResponse> response) {
-        final HttpStatusCode statusCode = response.getStatusCode();
-        if (!statusCode.is2xxSuccessful()) {
-            throw new IllegalArgumentException(String.format("외부 서버와의 연결에 실패하였습니다. [%s]", statusCode));
-        }
-    }
+    TokenResponse requestAccessToken(String authorizationCode, String redirectUrl);
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/OAuthProvider.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/OAuthProvider.java
@@ -10,6 +10,8 @@ public interface OAuthProvider {
 
     String generateOAuthUrl(String redirectUrl, String referrer);
 
+    String generateTokenUrl(String authorizationCode, String redirectUrl);
+
     HttpEntity<MultiValueMap<String, String>> createEntity(String authorizationCode, String redirectUrl);
 
     String getAccessTokenUrl();

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/OAuthProvider.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/OAuthProvider.java
@@ -12,9 +12,7 @@ public interface OAuthProvider {
 
     String generateTokenUrl(String authorizationCode, String redirectUrl);
 
-    HttpEntity<MultiValueMap<String, String>> createEntity(String authorizationCode, String redirectUrl);
-
-    String getAccessTokenUrl();
+    HttpEntity<MultiValueMap<String, String>> createEntity();
 
     default String concatParams(final Map<String, String> params) {
         return params.entrySet()

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/response/GoogleTokenResponse.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/response/GoogleTokenResponse.java
@@ -1,0 +1,4 @@
+package com.dobugs.yologaauthenticationapi.support.dto.response;
+
+public record GoogleTokenResponse(String access_token, int expires_in, String token_type, String scope, String refresh_token) {
+}

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/response/KakaoTokenResponse.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/response/KakaoTokenResponse.java
@@ -1,0 +1,4 @@
+package com.dobugs.yologaauthenticationapi.support.dto.response;
+
+public record KakaoTokenResponse(String token_type, String access_token, int expires_in, String refresh_token, int refresh_token_expires_in) {
+}

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/response/TokenResponse.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/response/TokenResponse.java
@@ -1,4 +1,4 @@
 package com.dobugs.yologaauthenticationapi.support.dto.response;
 
-public record TokenResponse(String accessToken) {
+public record TokenResponse(String accessToken, String refreshToken) {
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleConnector.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleConnector.java
@@ -2,11 +2,13 @@ package com.dobugs.yologaauthenticationapi.support.google;
 
 import java.util.Optional;
 
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 
 import com.dobugs.yologaauthenticationapi.support.OAuthConnector;
 import com.dobugs.yologaauthenticationapi.support.OAuthProvider;
+import com.dobugs.yologaauthenticationapi.support.dto.response.GoogleTokenResponse;
 import com.dobugs.yologaauthenticationapi.support.dto.response.TokenResponse;
 
 import lombok.Getter;
@@ -25,19 +27,26 @@ public class GoogleConnector implements OAuthConnector {
     }
 
     @Override
-    public String requestAccessToken(final String authorizationCode, final String redirectUrl) {
-        final TokenResponse response = connect(authorizationCode, redirectUrl);
-        return response.accessToken();
+    public TokenResponse requestAccessToken(final String authorizationCode, final String redirectUrl) {
+        final GoogleTokenResponse response = connect(authorizationCode, redirectUrl);
+        return new TokenResponse(response.access_token(), response.refresh_token());
     }
 
-    private TokenResponse connect(final String authorizationCode, final String redirectUrl) {
-        final ResponseEntity<TokenResponse> response = REST_TEMPLATE.postForEntity(
+    private GoogleTokenResponse connect(final String authorizationCode, final String redirectUrl) {
+        final ResponseEntity<GoogleTokenResponse> response = REST_TEMPLATE.postForEntity(
             googleProvider.generateTokenUrl(authorizationCode, redirectUrl),
             googleProvider.createEntity(),
-            TokenResponse.class
+            GoogleTokenResponse.class
         );
         validateConnectionResponseIsSuccess(response);
         return Optional.ofNullable(response.getBody())
             .orElseThrow(() -> new IllegalArgumentException("Google 과의 연결에 실패하였습니다."));
+    }
+
+    private void validateConnectionResponseIsSuccess(final ResponseEntity<GoogleTokenResponse> response) {
+        final HttpStatusCode statusCode = response.getStatusCode();
+        if (!statusCode.is2xxSuccessful()) {
+            throw new IllegalArgumentException(String.format("Google 과의 연결에 실패하였습니다. [%s]", statusCode));
+        }
     }
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleConnector.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleConnector.java
@@ -32,7 +32,7 @@ public class GoogleConnector implements OAuthConnector {
 
     private TokenResponse connect(final String authorizationCode, final String redirectUrl) {
         final ResponseEntity<TokenResponse> response = REST_TEMPLATE.postForEntity(
-            googleProvider.getAccessTokenUrl(),
+            googleProvider.generateTokenUrl(authorizationCode, redirectUrl),
             googleProvider.createEntity(authorizationCode, redirectUrl),
             TokenResponse.class
         );

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleConnector.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleConnector.java
@@ -27,7 +27,7 @@ public class GoogleConnector implements OAuthConnector {
     }
 
     @Override
-    public TokenResponse requestAccessToken(final String authorizationCode, final String redirectUrl) {
+    public TokenResponse requestToken(final String authorizationCode, final String redirectUrl) {
         final GoogleTokenResponse response = connect(authorizationCode, redirectUrl);
         return new TokenResponse(response.access_token(), response.refresh_token());
     }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleConnector.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleConnector.java
@@ -33,7 +33,7 @@ public class GoogleConnector implements OAuthConnector {
     private TokenResponse connect(final String authorizationCode, final String redirectUrl) {
         final ResponseEntity<TokenResponse> response = REST_TEMPLATE.postForEntity(
             googleProvider.generateTokenUrl(authorizationCode, redirectUrl),
-            googleProvider.createEntity(authorizationCode, redirectUrl),
+            googleProvider.createEntity(),
             TokenResponse.class
         );
         validateConnectionResponseIsSuccess(response);

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleProvider.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleProvider.java
@@ -56,24 +56,24 @@ public class GoogleProvider implements OAuthProvider {
     }
 
     @Override
+    public String generateTokenUrl(final String authorizationCode, final String redirectUrl) {
+        final Map<String, String> params = new HashMap<>();
+        params.put("code", authorizationCode);
+        params.put("client_id", clientId);
+        params.put("client_secret", clientSecret);
+        params.put("redirect_uri", redirectUrl);
+        params.put("grant_type", grantType);
+        return accessTokenUrl + "?" + concatParams(params);
+    }
+
+    @Override
     public HttpEntity<MultiValueMap<String, String>> createEntity(
         final String authorizationCode,
         final String redirectUrl
     ) {
         return new HttpEntity<>(
-            createBody(authorizationCode, redirectUrl),
             createHeaders()
         );
-    }
-
-    private MultiValueMap<String, String> createBody(final String authorizationCode, final String redirectUrl) {
-        final MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
-        body.add("code", authorizationCode);
-        body.add("client_id", clientId);
-        body.add("client_secret", clientSecret);
-        body.add("redirect_uri", redirectUrl);
-        body.add("grant_type", grantType);
-        return body;
     }
 
     private HttpHeaders createHeaders() {

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleProvider.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleProvider.java
@@ -18,8 +18,6 @@ import lombok.Getter;
 @Component
 public class GoogleProvider implements OAuthProvider {
 
-    private static final Map<String, String> params = new HashMap<>();
-
     private final String clientId;
     private final String clientSecret;
     private final String accessType;
@@ -44,12 +42,16 @@ public class GoogleProvider implements OAuthProvider {
         this.authUrl = authUrl;
         this.accessTokenUrl = accessTokenUrl;
         this.grantType = grantType;
-        setParams();
     }
 
     @Override
     public String generateOAuthUrl(final String redirectUrl, final String referrer) {
+        final Map<String, String> params = new HashMap<>();
+        params.put("client_id", clientId);
         params.put("redirect_uri", redirectUrl);
+        params.put("response_type", "code");
+        params.put("scope", scope);
+        params.put("access_type", accessType);
         params.put("referrer", referrer);
         return authUrl + "?" + concatParams(params);
     }
@@ -76,12 +78,5 @@ public class GoogleProvider implements OAuthProvider {
         final HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
         return headers;
-    }
-
-    private void setParams() {
-        params.put("scope", scope);
-        params.put("access_type", accessType);
-        params.put("response_type", "code");
-        params.put("client_id", clientId);
     }
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleProvider.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleProvider.java
@@ -8,7 +8,6 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
-import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
 import com.dobugs.yologaauthenticationapi.support.OAuthProvider;
@@ -67,10 +66,7 @@ public class GoogleProvider implements OAuthProvider {
     }
 
     @Override
-    public HttpEntity<MultiValueMap<String, String>> createEntity(
-        final String authorizationCode,
-        final String redirectUrl
-    ) {
+    public HttpEntity<MultiValueMap<String, String>> createEntity() {
         return new HttpEntity<>(
             createHeaders()
         );

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleProvider.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleProvider.java
@@ -23,6 +23,7 @@ public class GoogleProvider implements OAuthProvider {
 
     private final String clientId;
     private final String clientSecret;
+    private final String accessType;
     private final String scope;
     private final String authUrl;
     private final String accessTokenUrl;
@@ -32,12 +33,14 @@ public class GoogleProvider implements OAuthProvider {
         @Value("${oauth2.google.client.id}") final String clientId,
         @Value("${oauth2.google.client.secret}") final String clientSecret,
         @Value("${oauth2.google.scope}") final String scope,
+        @Value("${oauth2.google.access-type}") final String accessType,
         @Value("${oauth2.google.url.auth}") final String authUrl,
         @Value("${oauth2.google.url.token}") final String accessTokenUrl,
         @Value("${oauth2.google.grant-type}") final String grantType
     ) {
         this.clientId = clientId;
         this.clientSecret = clientSecret;
+        this.accessType = accessType;
         this.scope = scope;
         this.authUrl = authUrl;
         this.accessTokenUrl = accessTokenUrl;
@@ -81,6 +84,7 @@ public class GoogleProvider implements OAuthProvider {
 
     private void setParams() {
         params.put("scope", scope);
+        params.put("access_type", accessType);
         params.put("response_type", "code");
         params.put("client_id", clientId);
     }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoConnector.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoConnector.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 
 import com.dobugs.yologaauthenticationapi.support.OAuthConnector;
 import com.dobugs.yologaauthenticationapi.support.OAuthProvider;
-import com.dobugs.yologaauthenticationapi.support.dto.response.GoogleTokenResponse;
+import com.dobugs.yologaauthenticationapi.support.dto.response.KakaoTokenResponse;
 import com.dobugs.yologaauthenticationapi.support.dto.response.TokenResponse;
 
 import lombok.Getter;
@@ -28,22 +28,22 @@ public class KakaoConnector implements OAuthConnector {
 
     @Override
     public TokenResponse requestAccessToken(final String authorizationCode, final String redirectUrl) {
-        final GoogleTokenResponse response = connect(authorizationCode, redirectUrl);
+        final KakaoTokenResponse response = connect(authorizationCode, redirectUrl);
         return new TokenResponse(response.access_token(), response.refresh_token());
     }
 
-    private GoogleTokenResponse connect(final String authorizationCode, final String redirectUrl) {
-        final ResponseEntity<GoogleTokenResponse> response = REST_TEMPLATE.postForEntity(
+    private KakaoTokenResponse connect(final String authorizationCode, final String redirectUrl) {
+        final ResponseEntity<KakaoTokenResponse> response = REST_TEMPLATE.postForEntity(
             kakaoProvider.generateTokenUrl(authorizationCode, redirectUrl),
             kakaoProvider.createEntity(),
-            GoogleTokenResponse.class
+            KakaoTokenResponse.class
         );
         validateConnectionResponseIsSuccess(response);
         return Optional.ofNullable(response.getBody())
             .orElseThrow(() -> new IllegalArgumentException("kakao 와의 연결에 실패하였습니다."));
     }
 
-    private void validateConnectionResponseIsSuccess(final ResponseEntity<GoogleTokenResponse> response) {
+    private void validateConnectionResponseIsSuccess(final ResponseEntity<KakaoTokenResponse> response) {
         final HttpStatusCode statusCode = response.getStatusCode();
         if (!statusCode.is2xxSuccessful()) {
             throw new IllegalArgumentException(String.format("kakao 와의 연결에 실패하였습니다. [%s]", statusCode));

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoConnector.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoConnector.java
@@ -27,7 +27,7 @@ public class KakaoConnector implements OAuthConnector {
     }
 
     @Override
-    public TokenResponse requestAccessToken(final String authorizationCode, final String redirectUrl) {
+    public TokenResponse requestToken(final String authorizationCode, final String redirectUrl) {
         final KakaoTokenResponse response = connect(authorizationCode, redirectUrl);
         return new TokenResponse(response.access_token(), response.refresh_token());
     }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoConnector.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoConnector.java
@@ -2,11 +2,13 @@ package com.dobugs.yologaauthenticationapi.support.kakao;
 
 import java.util.Optional;
 
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 
 import com.dobugs.yologaauthenticationapi.support.OAuthConnector;
 import com.dobugs.yologaauthenticationapi.support.OAuthProvider;
+import com.dobugs.yologaauthenticationapi.support.dto.response.GoogleTokenResponse;
 import com.dobugs.yologaauthenticationapi.support.dto.response.TokenResponse;
 
 import lombok.Getter;
@@ -25,19 +27,26 @@ public class KakaoConnector implements OAuthConnector {
     }
 
     @Override
-    public String requestAccessToken(final String authorizationCode, final String redirectUrl) {
-        final TokenResponse response = connect(authorizationCode, redirectUrl);
-        return response.accessToken();
+    public TokenResponse requestAccessToken(final String authorizationCode, final String redirectUrl) {
+        final GoogleTokenResponse response = connect(authorizationCode, redirectUrl);
+        return new TokenResponse(response.access_token(), response.refresh_token());
     }
 
-    private TokenResponse connect(final String authorizationCode, final String redirectUrl) {
-        final ResponseEntity<TokenResponse> response = REST_TEMPLATE.postForEntity(
+    private GoogleTokenResponse connect(final String authorizationCode, final String redirectUrl) {
+        final ResponseEntity<GoogleTokenResponse> response = REST_TEMPLATE.postForEntity(
             kakaoProvider.generateTokenUrl(authorizationCode, redirectUrl),
             kakaoProvider.createEntity(),
-            TokenResponse.class
+            GoogleTokenResponse.class
         );
         validateConnectionResponseIsSuccess(response);
         return Optional.ofNullable(response.getBody())
             .orElseThrow(() -> new IllegalArgumentException("kakao 와의 연결에 실패하였습니다."));
+    }
+
+    private void validateConnectionResponseIsSuccess(final ResponseEntity<GoogleTokenResponse> response) {
+        final HttpStatusCode statusCode = response.getStatusCode();
+        if (!statusCode.is2xxSuccessful()) {
+            throw new IllegalArgumentException(String.format("kakao 와의 연결에 실패하였습니다. [%s]", statusCode));
+        }
     }
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoConnector.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoConnector.java
@@ -33,7 +33,7 @@ public class KakaoConnector implements OAuthConnector {
     private TokenResponse connect(final String authorizationCode, final String redirectUrl) {
         final ResponseEntity<TokenResponse> response = REST_TEMPLATE.postForEntity(
             kakaoProvider.generateTokenUrl(authorizationCode, redirectUrl),
-            kakaoProvider.createEntity(authorizationCode, redirectUrl),
+            kakaoProvider.createEntity(),
             TokenResponse.class
         );
         validateConnectionResponseIsSuccess(response);

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoConnector.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoConnector.java
@@ -32,7 +32,7 @@ public class KakaoConnector implements OAuthConnector {
 
     private TokenResponse connect(final String authorizationCode, final String redirectUrl) {
         final ResponseEntity<TokenResponse> response = REST_TEMPLATE.postForEntity(
-            kakaoProvider.getAccessTokenUrl(),
+            kakaoProvider.generateTokenUrl(authorizationCode, redirectUrl),
             kakaoProvider.createEntity(authorizationCode, redirectUrl),
             TokenResponse.class
         );

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoProvider.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoProvider.java
@@ -8,7 +8,6 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
-import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
 import com.dobugs.yologaauthenticationapi.support.OAuthProvider;
@@ -57,23 +56,10 @@ public class KakaoProvider implements OAuthProvider {
     }
 
     @Override
-    public HttpEntity<MultiValueMap<String, String>> createEntity(
-        final String authorizationCode,
-        final String redirectUrl
-    ) {
+    public HttpEntity<MultiValueMap<String, String>> createEntity() {
         return new HttpEntity<>(
-            createBody(authorizationCode, redirectUrl),
             createHeaders()
         );
-    }
-
-    private MultiValueMap<String, String> createBody(final String authorizationCode, final String redirectUrl) {
-        final MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
-        body.add("code", authorizationCode);
-        body.add("client_id", clientId);
-        body.add("redirect_uri", redirectUrl);
-        body.add("grant_type", grantType);
-        return body;
     }
 
     private HttpHeaders createHeaders() {

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoProvider.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoProvider.java
@@ -18,8 +18,6 @@ import lombok.Getter;
 @Component
 public class KakaoProvider implements OAuthProvider {
 
-    private static final Map<String, String> params = new HashMap<>();
-
     private final String clientId;
     private final String authUrl;
     private final String accessTokenUrl;
@@ -35,12 +33,14 @@ public class KakaoProvider implements OAuthProvider {
         this.authUrl = authUrl;
         this.accessTokenUrl = accessTokenUrl;
         this.grantType = grantType;
-        setParams();
     }
 
     @Override
     public String generateOAuthUrl(final String redirectUrl, final String referrer) {
+        final Map<String, String> params = new HashMap<>();
+        params.put("client_id", clientId);
         params.put("redirect_uri", redirectUrl);
+        params.put("response_type", "code");
         params.put("referrer", referrer);
         return authUrl + "?" + concatParams(params);
     }
@@ -66,10 +66,5 @@ public class KakaoProvider implements OAuthProvider {
         final HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
         return headers;
-    }
-
-    private void setParams() {
-        params.put("client_id", clientId);
-        params.put("response_type", "code");
     }
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoProvider.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoProvider.java
@@ -47,6 +47,16 @@ public class KakaoProvider implements OAuthProvider {
     }
 
     @Override
+    public String generateTokenUrl(final String authorizationCode, final String redirectUrl) {
+        final Map<String, String> params = new HashMap<>();
+        params.put("code", authorizationCode);
+        params.put("client_id", clientId);
+        params.put("redirect_uri", redirectUrl);
+        params.put("grant_type", grantType);
+        return accessTokenUrl + "?" + concatParams(params);
+    }
+
+    @Override
     public HttpEntity<MultiValueMap<String, String>> createEntity(
         final String authorizationCode,
         final String redirectUrl

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/FakeConnector.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/FakeConnector.java
@@ -2,6 +2,7 @@ package com.dobugs.yologaauthenticationapi.service;
 
 import com.dobugs.yologaauthenticationapi.support.OAuthConnector;
 import com.dobugs.yologaauthenticationapi.support.OAuthProvider;
+import com.dobugs.yologaauthenticationapi.support.dto.response.TokenResponse;
 
 public class FakeConnector implements OAuthConnector {
 
@@ -13,7 +14,7 @@ public class FakeConnector implements OAuthConnector {
     }
 
     @Override
-    public String requestAccessToken(final String authorizationCode, final String redirectUrl) {
+    public TokenResponse requestAccessToken(final String authorizationCode, final String redirectUrl) {
         return null;
     }
 }

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/FakeConnector.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/FakeConnector.java
@@ -14,7 +14,7 @@ public class FakeConnector implements OAuthConnector {
     }
 
     @Override
-    public TokenResponse requestAccessToken(final String authorizationCode, final String redirectUrl) {
+    public TokenResponse requestToken(final String authorizationCode, final String redirectUrl) {
         return null;
     }
 }

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/FakeProvider.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/FakeProvider.java
@@ -38,15 +38,7 @@ public class FakeProvider implements OAuthProvider {
     }
 
     @Override
-    public HttpEntity<MultiValueMap<String, String>> createEntity(
-        final String authorizationCode,
-        final String redirectUrl
-    ) {
-        return null;
-    }
-
-    @Override
-    public String getAccessTokenUrl() {
+    public HttpEntity<MultiValueMap<String, String>> createEntity() {
         return null;
     }
 

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/FakeProvider.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/FakeProvider.java
@@ -2,7 +2,6 @@ package com.dobugs.yologaauthenticationapi.service;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.springframework.http.HttpEntity;
 import org.springframework.util.MultiValueMap;
@@ -38,12 +37,5 @@ public class FakeProvider implements OAuthProvider {
     @Override
     public HttpEntity<MultiValueMap<String, String>> createEntity() {
         return null;
-    }
-
-    public String concatParams(final Map<String, String> params) {
-        return params.entrySet()
-            .stream()
-            .map(entry -> entry.getKey() + "=" + entry.getValue())
-            .collect(Collectors.joining("&"));
     }
 }

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/FakeProvider.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/FakeProvider.java
@@ -16,6 +16,7 @@ public class FakeProvider implements OAuthProvider {
     private static final String CLIENT_ID = "clientId";
     private static final String SCOPE = "scope";
     private static final String AUTH_URL = "authUrl";
+    private static final String TOKEN_URL = "tokenUrl";
 
     public FakeProvider() {
         setParams();
@@ -25,7 +26,15 @@ public class FakeProvider implements OAuthProvider {
     public String generateOAuthUrl(final String redirectUrl, final String referrer) {
         params.put("redirect_uri", redirectUrl);
         params.put("referrer", referrer);
-        return AUTH_URL + "?" + concatParams();
+        return AUTH_URL + "?" + concatParams(params);
+    }
+
+    @Override
+    public String generateTokenUrl(final String authorizationCode, final String redirectUrl) {
+        final Map<String, String> params = new HashMap<>();
+        params.put("code", authorizationCode);
+        params.put("redirect_url", redirectUrl);
+        return TOKEN_URL + "?" + concatParams(params);
     }
 
     @Override
@@ -41,7 +50,7 @@ public class FakeProvider implements OAuthProvider {
         return null;
     }
 
-    public String concatParams() {
+    public String concatParams(final Map<String, String> params) {
         return params.entrySet()
             .stream()
             .map(entry -> entry.getKey() + "=" + entry.getValue())

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/FakeProvider.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/FakeProvider.java
@@ -11,20 +11,18 @@ import com.dobugs.yologaauthenticationapi.support.OAuthProvider;
 
 public class FakeProvider implements OAuthProvider {
 
-    private final Map<String, String> params = new HashMap<>();
-
     private static final String CLIENT_ID = "clientId";
     private static final String SCOPE = "scope";
     private static final String AUTH_URL = "authUrl";
     private static final String TOKEN_URL = "tokenUrl";
 
-    public FakeProvider() {
-        setParams();
-    }
-
     @Override
     public String generateOAuthUrl(final String redirectUrl, final String referrer) {
+        final Map<String, String> params = new HashMap<>();
+        params.put("client_id", CLIENT_ID);
         params.put("redirect_uri", redirectUrl);
+        params.put("response_type", "code");
+        params.put("scope", SCOPE);
         params.put("referrer", referrer);
         return AUTH_URL + "?" + concatParams(params);
     }
@@ -47,11 +45,5 @@ public class FakeProvider implements OAuthProvider {
             .stream()
             .map(entry -> entry.getKey() + "=" + entry.getValue())
             .collect(Collectors.joining("&"));
-    }
-
-    private void setParams() {
-        params.put("scope", SCOPE);
-        params.put("response_type", "code");
-        params.put("client_id", CLIENT_ID);
     }
 }


### PR DESCRIPTION
## *관련 작업 티켓

- https://dobugs.atlassian.net/browse/YOL-111
 
## *작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- [예전 PR](https://github.com/dobugs/yologa-authentication-api/pull/2) 에서 발생했던 에러를 해결하고 OAuth 로그인 요청 시 토큰을 발급하는 기능을 구현하였습니다.
  - Google OAuth : malformed auth code
    - 첫 Google 서버에게 요청 시 include_granted_scopes 값 설정(이후에는 선택)
  - kakao OAuth : 200 Ok null 응답
    - 코드 상에서 지정한 DTO 의 이름과 카카오 서버에서 응답한 값의 이름 차이로 인해 추출 실패

## *추가되어야 할 기능

- 필수
  - 로그인
    - 외부 서버에서 받아온 accessToken 을 이용하여 사용자 정보 조회
    - 조회한 사용자 정보를 사용자 테이블에 저장
    - accessToken 과 refreshToken 을 Redis 에 저장
  - refreshToken 으로 accessToken 재발급
  - 로그아웃
- 선택 (유지보수 기간에 적용)
  - Spring security 적용

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)
