### PR TITLE
feat: Token 정보 Redis 에 저장

### DIFF
--- a/src/main/java/com/dobugs/yologaauthenticationapi/config/RedisConfiguration.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/config/RedisConfiguration.java
@@ -1,0 +1,32 @@
+package com.dobugs.yologaauthenticationapi.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfiguration {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/dobugs/yologaauthenticationapi/domain/OAuthToken.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/domain/OAuthToken.java
@@ -1,0 +1,22 @@
+package com.dobugs.yologaauthenticationapi.domain;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+@RedisHash
+public class OAuthToken {
+
+    @Id
+    private Long memberId;
+
+    private Provider provider;
+    private String accessToken;
+    private String refreshToken;
+
+    public static OAuthToken login(final Long memberId, final Provider provider, final String refreshToken) {
+        return new OAuthToken(memberId, provider, null, refreshToken);
+    }
+}

--- a/src/main/java/com/dobugs/yologaauthenticationapi/domain/Provider.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/domain/Provider.java
@@ -1,5 +1,7 @@
 package com.dobugs.yologaauthenticationapi.domain;
 
+import java.util.Arrays;
+
 import lombok.Getter;
 
 @Getter
@@ -13,5 +15,12 @@ public enum Provider {
 
     Provider(final String name) {
         this.name = name;
+    }
+
+    public static Provider findOf(final String other) {
+        return Arrays.stream(Provider.values())
+            .filter(provider -> provider.name.equals(other.toLowerCase()))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException(String.format("잘못된 provider 입니다. [%s]", other)));
     }
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/repository/OAuthRepository.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/repository/OAuthRepository.java
@@ -1,0 +1,8 @@
+package com.dobugs.yologaauthenticationapi.repository;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.dobugs.yologaauthenticationapi.domain.OAuthToken;
+
+public interface OAuthRepository extends CrudRepository<OAuthToken, Long> {
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,6 @@
+spring:
+  config:
+    activate:
+      on-profile: dev
+    import:
+      - yologa-security/application-dev-redis.yml

--- a/src/main/resources/application-local-redis.yml
+++ b/src/main/resources/application-local-redis.yml
@@ -1,0 +1,5 @@
+spring:
+  data:
+    redis:
+      host: 127.0.0.1
+      port: 6379

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,6 @@
+spring:
+  config:
+    activate:
+      on-profile: local
+    import:
+      - application-local-redis.yml

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,6 @@
 spring:
+  profiles:
+    active: local
   config:
     import:
       - yologa-security/application-oauth2.yml
-      - yologa-security/application-redis.yml

--- a/src/test/java/com/dobugs/yologaauthenticationapi/domain/ProviderTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/domain/ProviderTest.java
@@ -1,0 +1,35 @@
+package com.dobugs.yologaauthenticationapi.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayName("Provider 도메인 테스트")
+class ProviderTest {
+
+    @DisplayName("Provider 조회 테스트")
+    @Nested
+    public class findOf {
+
+        @DisplayName("google 을 조회한다")
+        @ParameterizedTest
+        @ValueSource(strings = {"google", "GOOGLE", "Google"})
+        void findGoogle(String providerName) {
+            final Provider provider = Provider.findOf(providerName);
+
+            assertThat(provider).isEqualTo(Provider.GOOGLE);
+        }
+
+        @DisplayName("kakao 를 조회한다")
+        @ParameterizedTest
+        @ValueSource(strings = {"kakao", "KAKAO", "Kakao"})
+        void findKakao(String providerName) {
+            final Provider provider = Provider.findOf(providerName);
+
+            assertThat(provider).isEqualTo(Provider.KAKAO);
+        }
+    }
+}

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/AuthServiceTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/AuthServiceTest.java
@@ -8,8 +8,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.dobugs.yologaauthenticationapi.repository.OAuthRepository;
 import com.dobugs.yologaauthenticationapi.service.dto.request.OAuthRequest;
 import com.dobugs.yologaauthenticationapi.service.dto.response.OAuthLinkResponse;
 import com.dobugs.yologaauthenticationapi.support.OAuthConnector;
@@ -23,15 +25,18 @@ class AuthServiceTest {
 
     private AuthService authService;
 
+    @Mock
+    private OAuthRepository oAuthRepository;
+
     @BeforeEach
     void setUp() {
         final OAuthConnector connector = new FakeConnector();
-        authService = new AuthService(connector, connector);
+        authService = new AuthService(connector, connector, oAuthRepository);
     }
 
     @DisplayName("OAuth URL 생성 테스트")
     @Nested
-    public class generateOAuthUrl {
+    public class generateOAuthTokenUrl {
 
         @DisplayName("구글 OAuth URL 을 생성한다")
         @Test


### PR DESCRIPTION
## *관련 작업 티켓

- https://dobugs.atlassian.net/browse/YOL-113

## *작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- OAuth 서버에서 받아온 AccessToken 과 RefreshToken 을 Redis 에 저장합니다.
- AWS 의 ElastiCache 는 외부 접속을 막아두었기 때문에 로컬과 개발 환경의 설정 파일(.yml) 을 분리하였습니다.

## 관련 Docs

- [Redis 적용 노션 정리](https://cactus-treatment-26e.notion.site/OAuth2-0-3-Redis-Blacklist-c9ddfe021895471f8772c398cef27956)
  - 현재 Redis 의 save 만을 사용해보았기 때문에 개발을 진행하면서 노션 문서 내용이 추가될 가능성이 있습니다.

## *추가되어야 할 기능

- 필수
  - 로그인
    - 외부 서버에서 받아온 accessToken 을 이용하여 사용자 정보 조회
    - 조회한 사용자 정보를 사용자 테이블에 저장
  - refreshToken 으로 accessToken 재발급
  - 로그아웃
- 선택 (유지보수 기간에 적용)
  - Spring security 적용

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)
