### PR TITLE
feat: OAuth 로그인 시 DB 에 사용자 정보 저장

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,9 +19,13 @@ configurations {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    // jpa
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     // lombok
     implementation 'org.projectlombok:lombok'
@@ -30,6 +34,9 @@ dependencies {
     // rest docs
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+
+    // mysql
+    runtimeOnly 'mysql:mysql-connector-java:8.0.28'
 }
 
 /* RestDocs Start */

--- a/src/main/java/com/dobugs/yologaauthenticationapi/domain/BaseEntity.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/domain/BaseEntity.java
@@ -1,0 +1,33 @@
+package com.dobugs.yologaauthenticationapi.domain;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @Column
+    private boolean archived = true;
+
+    @Column
+    private LocalDateTime archivedAt;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    public void delete() {
+        archived = false;
+        archivedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/dobugs/yologaauthenticationapi/domain/Member.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/domain/Member.java
@@ -1,0 +1,33 @@
+package com.dobugs.yologaauthenticationapi.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String oauthId;
+
+    @Column
+    private String nickname;
+
+    @Column
+    private int resourceId;
+
+    public Member(final String oauthId) {
+        this.oauthId = oauthId;
+    }
+}

--- a/src/main/java/com/dobugs/yologaauthenticationapi/repository/MemberRepository.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/repository/MemberRepository.java
@@ -1,0 +1,12 @@
+package com.dobugs.yologaauthenticationapi.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.dobugs.yologaauthenticationapi.domain.Member;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByOauthId(String oauthId);
+}

--- a/src/main/java/com/dobugs/yologaauthenticationapi/service/AuthService.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/service/AuthService.java
@@ -15,6 +15,7 @@ import com.dobugs.yologaauthenticationapi.service.dto.response.OAuthLinkResponse
 import com.dobugs.yologaauthenticationapi.service.dto.response.OAuthTokenResponse;
 import com.dobugs.yologaauthenticationapi.support.OAuthConnector;
 import com.dobugs.yologaauthenticationapi.support.dto.response.TokenResponse;
+import com.dobugs.yologaauthenticationapi.support.dto.response.UserResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -45,6 +46,8 @@ public class AuthService {
         final String authorizationCode = decode(codeRequest.authorizationCode());
 
         final TokenResponse tokenResponse = oAuthConnector.requestToken(authorizationCode, redirectUrl);
+        final UserResponse userResponse = oAuthConnector.requestUserInfo(tokenResponse.tokenType(), tokenResponse.accessToken());
+
         final OAuthToken oAuthToken = OAuthToken.login(1L, Provider.findOf(provider), tokenResponse.refreshToken());
         oAuthRepository.save(oAuthToken);
         return new OAuthTokenResponse(tokenResponse.accessToken(), tokenResponse.refreshToken());

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/OAuthConnector.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/OAuthConnector.java
@@ -3,6 +3,7 @@ package com.dobugs.yologaauthenticationapi.support;
 import org.springframework.web.client.RestTemplate;
 
 import com.dobugs.yologaauthenticationapi.support.dto.response.TokenResponse;
+import com.dobugs.yologaauthenticationapi.support.dto.response.UserResponse;
 
 public interface OAuthConnector {
 
@@ -11,4 +12,6 @@ public interface OAuthConnector {
     String generateOAuthUrl(String redirectUrl, String referrer);
 
     TokenResponse requestToken(String authorizationCode, String redirectUrl);
+
+    UserResponse requestUserInfo(String tokenType, String accessToken);
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/OAuthProvider.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/OAuthProvider.java
@@ -12,7 +12,11 @@ public interface OAuthProvider {
 
     String generateTokenUrl(String authorizationCode, String redirectUrl);
 
-    HttpEntity<MultiValueMap<String, String>> createEntity();
+    String generateUserInfoUrl();
+
+    HttpEntity<MultiValueMap<String, String>> createTokenEntity();
+
+    HttpEntity<MultiValueMap<String, String>> createUserEntity(String tokenType, String accessToken);
 
     default String concatParams(final Map<String, String> params) {
         return params.entrySet()

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/response/GoogleUserResponse.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/response/GoogleUserResponse.java
@@ -1,0 +1,4 @@
+package com.dobugs.yologaauthenticationapi.support.dto.response;
+
+public record GoogleUserResponse(String id, String email, String name, String picture) {
+}

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/response/KakaoUserResponse.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/response/KakaoUserResponse.java
@@ -1,0 +1,4 @@
+package com.dobugs.yologaauthenticationapi.support.dto.response;
+
+public record KakaoUserResponse(String id) {
+}

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/response/TokenResponse.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/response/TokenResponse.java
@@ -1,4 +1,4 @@
 package com.dobugs.yologaauthenticationapi.support.dto.response;
 
-public record TokenResponse(String accessToken, String refreshToken) {
+public record TokenResponse(String accessToken, String refreshToken, String tokenType) {
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/response/UserResponse.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/response/UserResponse.java
@@ -1,0 +1,4 @@
+package com.dobugs.yologaauthenticationapi.support.dto.response;
+
+public record UserResponse(String oAuthId) {
+}

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleConnector.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleConnector.java
@@ -2,6 +2,7 @@ package com.dobugs.yologaauthenticationapi.support.google;
 
 import java.util.Optional;
 
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
@@ -9,7 +10,9 @@ import org.springframework.stereotype.Component;
 import com.dobugs.yologaauthenticationapi.support.OAuthConnector;
 import com.dobugs.yologaauthenticationapi.support.OAuthProvider;
 import com.dobugs.yologaauthenticationapi.support.dto.response.GoogleTokenResponse;
+import com.dobugs.yologaauthenticationapi.support.dto.response.GoogleUserResponse;
 import com.dobugs.yologaauthenticationapi.support.dto.response.TokenResponse;
+import com.dobugs.yologaauthenticationapi.support.dto.response.UserResponse;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -28,22 +31,40 @@ public class GoogleConnector implements OAuthConnector {
 
     @Override
     public TokenResponse requestToken(final String authorizationCode, final String redirectUrl) {
-        final GoogleTokenResponse response = connect(authorizationCode, redirectUrl);
-        return new TokenResponse(response.access_token(), response.refresh_token());
+        final GoogleTokenResponse response = connectForToken(authorizationCode, redirectUrl);
+        return new TokenResponse(response.access_token(), response.refresh_token(), response.token_type());
     }
 
-    private GoogleTokenResponse connect(final String authorizationCode, final String redirectUrl) {
+    @Override
+    public UserResponse requestUserInfo(final String tokenType, final String accessToken) {
+        final GoogleUserResponse response = connectForUserInfo(tokenType, accessToken);
+        return new UserResponse(response.id());
+    }
+
+    private GoogleTokenResponse connectForToken(final String authorizationCode, final String redirectUrl) {
         final ResponseEntity<GoogleTokenResponse> response = REST_TEMPLATE.postForEntity(
             googleProvider.generateTokenUrl(authorizationCode, redirectUrl),
-            googleProvider.createEntity(),
+            googleProvider.createTokenEntity(),
             GoogleTokenResponse.class
         );
         validateConnectionResponseIsSuccess(response);
         return Optional.ofNullable(response.getBody())
-            .orElseThrow(() -> new IllegalArgumentException("Google 과의 연결에 실패하였습니다."));
+            .orElseThrow(() -> new IllegalArgumentException("Google 의 Token 정보를 가져오는 과정에서 연결에 실패하였습니다."));
     }
 
-    private void validateConnectionResponseIsSuccess(final ResponseEntity<GoogleTokenResponse> response) {
+    private GoogleUserResponse connectForUserInfo(final String tokenType, final String accessToken) {
+        final ResponseEntity<GoogleUserResponse> response = REST_TEMPLATE.exchange(
+            googleProvider.generateUserInfoUrl(),
+            HttpMethod.GET,
+            googleProvider.createUserEntity(tokenType, accessToken),
+            GoogleUserResponse.class
+        );
+        validateConnectionResponseIsSuccess(response);
+        return Optional.ofNullable(response.getBody())
+            .orElseThrow(() -> new IllegalArgumentException("Google 의 사용자 정보를 가져오는 과정에서 연결에 실패하였습니다."));
+    }
+
+    private void validateConnectionResponseIsSuccess(final ResponseEntity<?> response) {
         final HttpStatusCode statusCode = response.getStatusCode();
         if (!statusCode.is2xxSuccessful()) {
             throw new IllegalArgumentException(String.format("Google 과의 연결에 실패하였습니다. [%s]", statusCode));

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleProvider.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleProvider.java
@@ -24,6 +24,7 @@ public class GoogleProvider implements OAuthProvider {
     private final String scope;
     private final String authUrl;
     private final String accessTokenUrl;
+    private final String userInfoUrl;
     private final String grantType;
 
     public GoogleProvider(
@@ -33,6 +34,7 @@ public class GoogleProvider implements OAuthProvider {
         @Value("${oauth2.google.access-type}") final String accessType,
         @Value("${oauth2.google.url.auth}") final String authUrl,
         @Value("${oauth2.google.url.token}") final String accessTokenUrl,
+        @Value("${oauth2.google.url.userinfo}") final String userInfoUrl,
         @Value("${oauth2.google.grant-type}") final String grantType
     ) {
         this.clientId = clientId;
@@ -41,6 +43,7 @@ public class GoogleProvider implements OAuthProvider {
         this.scope = scope;
         this.authUrl = authUrl;
         this.accessTokenUrl = accessTokenUrl;
+        this.userInfoUrl = userInfoUrl;
         this.grantType = grantType;
     }
 
@@ -68,15 +71,33 @@ public class GoogleProvider implements OAuthProvider {
     }
 
     @Override
-    public HttpEntity<MultiValueMap<String, String>> createEntity() {
+    public String generateUserInfoUrl() {
+        return userInfoUrl;
+    }
+
+    @Override
+    public HttpEntity<MultiValueMap<String, String>> createTokenEntity() {
         return new HttpEntity<>(
-            createHeaders()
+            createTokenHeaders()
         );
     }
 
-    private HttpHeaders createHeaders() {
+    @Override
+    public HttpEntity<MultiValueMap<String, String>> createUserEntity(final String tokenType, final String accessToken) {
+        return new HttpEntity<>(
+            createUserHeaders(tokenType, accessToken)
+        );
+    }
+
+    private HttpHeaders createTokenHeaders() {
         final HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        return headers;
+    }
+
+    private HttpHeaders createUserHeaders(final String tokenType, final String accessToken) {
+        final HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", String.join(" ", tokenType, accessToken));
         return headers;
     }
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoConnector.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoConnector.java
@@ -10,6 +10,7 @@ import com.dobugs.yologaauthenticationapi.support.OAuthConnector;
 import com.dobugs.yologaauthenticationapi.support.OAuthProvider;
 import com.dobugs.yologaauthenticationapi.support.dto.response.KakaoTokenResponse;
 import com.dobugs.yologaauthenticationapi.support.dto.response.TokenResponse;
+import com.dobugs.yologaauthenticationapi.support.dto.response.UserResponse;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -29,13 +30,18 @@ public class KakaoConnector implements OAuthConnector {
     @Override
     public TokenResponse requestToken(final String authorizationCode, final String redirectUrl) {
         final KakaoTokenResponse response = connect(authorizationCode, redirectUrl);
-        return new TokenResponse(response.access_token(), response.refresh_token());
+        return new TokenResponse(response.access_token(), response.refresh_token(), response.token_type());
+    }
+
+    @Override
+    public UserResponse requestUserInfo(final String tokenType, final String accessToken) {
+        return null;
     }
 
     private KakaoTokenResponse connect(final String authorizationCode, final String redirectUrl) {
         final ResponseEntity<KakaoTokenResponse> response = REST_TEMPLATE.postForEntity(
             kakaoProvider.generateTokenUrl(authorizationCode, redirectUrl),
-            kakaoProvider.createEntity(),
+            kakaoProvider.createTokenEntity(),
             KakaoTokenResponse.class
         );
         validateConnectionResponseIsSuccess(response);

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoConnector.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoConnector.java
@@ -2,6 +2,7 @@ package com.dobugs.yologaauthenticationapi.support.kakao;
 
 import java.util.Optional;
 
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
@@ -9,6 +10,7 @@ import org.springframework.stereotype.Component;
 import com.dobugs.yologaauthenticationapi.support.OAuthConnector;
 import com.dobugs.yologaauthenticationapi.support.OAuthProvider;
 import com.dobugs.yologaauthenticationapi.support.dto.response.KakaoTokenResponse;
+import com.dobugs.yologaauthenticationapi.support.dto.response.KakaoUserResponse;
 import com.dobugs.yologaauthenticationapi.support.dto.response.TokenResponse;
 import com.dobugs.yologaauthenticationapi.support.dto.response.UserResponse;
 
@@ -29,16 +31,17 @@ public class KakaoConnector implements OAuthConnector {
 
     @Override
     public TokenResponse requestToken(final String authorizationCode, final String redirectUrl) {
-        final KakaoTokenResponse response = connect(authorizationCode, redirectUrl);
+        final KakaoTokenResponse response = connectForToken(authorizationCode, redirectUrl);
         return new TokenResponse(response.access_token(), response.refresh_token(), response.token_type());
     }
 
     @Override
     public UserResponse requestUserInfo(final String tokenType, final String accessToken) {
-        return null;
+        final KakaoUserResponse response = connectForUserInfo(tokenType, accessToken);
+        return new UserResponse(response.id());
     }
 
-    private KakaoTokenResponse connect(final String authorizationCode, final String redirectUrl) {
+    private KakaoTokenResponse connectForToken(final String authorizationCode, final String redirectUrl) {
         final ResponseEntity<KakaoTokenResponse> response = REST_TEMPLATE.postForEntity(
             kakaoProvider.generateTokenUrl(authorizationCode, redirectUrl),
             kakaoProvider.createTokenEntity(),
@@ -49,7 +52,19 @@ public class KakaoConnector implements OAuthConnector {
             .orElseThrow(() -> new IllegalArgumentException("kakao 와의 연결에 실패하였습니다."));
     }
 
-    private void validateConnectionResponseIsSuccess(final ResponseEntity<KakaoTokenResponse> response) {
+    private KakaoUserResponse connectForUserInfo(final String tokenType, final String accessToken) {
+        final ResponseEntity<KakaoUserResponse> response = REST_TEMPLATE.exchange(
+            kakaoProvider.generateUserInfoUrl(),
+            HttpMethod.GET,
+            kakaoProvider.createUserEntity(tokenType, accessToken),
+            KakaoUserResponse.class
+        );
+        validateConnectionResponseIsSuccess(response);
+        return Optional.ofNullable(response.getBody())
+            .orElseThrow(() -> new IllegalArgumentException("Google 의 사용자 정보를 가져오는 과정에서 연결에 실패하였습니다."));
+    }
+
+    private void validateConnectionResponseIsSuccess(final ResponseEntity<?> response) {
         final HttpStatusCode statusCode = response.getStatusCode();
         if (!statusCode.is2xxSuccessful()) {
             throw new IllegalArgumentException(String.format("kakao 와의 연결에 실패하였습니다. [%s]", statusCode));

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoProvider.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoProvider.java
@@ -56,10 +56,20 @@ public class KakaoProvider implements OAuthProvider {
     }
 
     @Override
-    public HttpEntity<MultiValueMap<String, String>> createEntity() {
+    public String generateUserInfoUrl() {
+        return null;
+    }
+
+    @Override
+    public HttpEntity<MultiValueMap<String, String>> createTokenEntity() {
         return new HttpEntity<>(
             createHeaders()
         );
+    }
+
+    @Override
+    public HttpEntity<MultiValueMap<String, String>> createUserEntity(final String tokenType, final String accessToken) {
+        return null;
     }
 
     private HttpHeaders createHeaders() {

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoProvider.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoProvider.java
@@ -21,17 +21,20 @@ public class KakaoProvider implements OAuthProvider {
     private final String clientId;
     private final String authUrl;
     private final String accessTokenUrl;
+    private final String userInfoUrl;
     private final String grantType;
 
     public KakaoProvider(
         @Value("${oauth2.kakao.client.id}") final String clientId,
         @Value("${oauth2.kakao.url.auth}") final String authUrl,
         @Value("${oauth2.kakao.url.token}") final String accessTokenUrl,
+        @Value("${oauth2.kakao.url.userinfo}") final String userInfoUrl,
         @Value("${oauth2.kakao.grant-type}") final String grantType
     ) {
         this.clientId = clientId;
         this.authUrl = authUrl;
         this.accessTokenUrl = accessTokenUrl;
+        this.userInfoUrl = userInfoUrl;
         this.grantType = grantType;
     }
 
@@ -57,7 +60,7 @@ public class KakaoProvider implements OAuthProvider {
 
     @Override
     public String generateUserInfoUrl() {
-        return null;
+        return userInfoUrl;
     }
 
     @Override
@@ -69,12 +72,20 @@ public class KakaoProvider implements OAuthProvider {
 
     @Override
     public HttpEntity<MultiValueMap<String, String>> createUserEntity(final String tokenType, final String accessToken) {
-        return null;
+        return new HttpEntity<>(
+            createUserHeaders(tokenType, accessToken)
+        );
     }
 
     private HttpHeaders createHeaders() {
         final HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        return headers;
+    }
+
+    private HttpHeaders createUserHeaders(final String tokenType, final String accessToken) {
+        final HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", String.join(" ", tokenType, accessToken));
         return headers;
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -4,3 +4,4 @@ spring:
       on-profile: dev
     import:
       - yologa-security/application-dev-redis.yml
+      - yologa-security/application-dev-db.yml

--- a/src/main/resources/application-local-db.yml
+++ b/src/main/resources/application-local-db.yml
@@ -1,0 +1,17 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: yologa
+    password: yologa
+    url: jdbc:mysql://localhost:3306/yologa?characterEncoding=UTF-8
+  jpa:
+    hibernate.ddl-auto: validate
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    properties:
+      hibernate:
+        format_sql: true
+    show-sql: true
+
+logging:
+  level:
+    org.hibernate.type.descriptor.sql.BasicBinder: TRACE

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -4,3 +4,4 @@ spring:
       on-profile: local
     import:
       - application-local-redis.yml
+      - application-local-db.yml

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: local
+    active: dev
   config:
     import:
       - yologa-security/application-oauth2.yml

--- a/src/test/java/com/dobugs/yologaauthenticationapi/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/repository/MemberRepositoryTest.java
@@ -1,0 +1,50 @@
+package com.dobugs.yologaauthenticationapi.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import com.dobugs.yologaauthenticationapi.domain.Member;
+
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DataJpaTest
+@DisplayName("Member 레파지토리 테스트")
+class MemberRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @DisplayName("OAuth ID 를 이용하여 Member 를 조회하는 테스트")
+    @Nested
+    public class findByOauthId {
+
+        @DisplayName("해당 OAuth ID 를 가지는 Member 를 조회한다")
+        @Test
+        void exist() {
+            final String oAuthId = "oauthID";
+            final Member member = new Member(oAuthId);
+            memberRepository.save(member);
+
+            final Optional<Member> savedMember = memberRepository.findByOauthId(oAuthId);
+
+            assertThat(savedMember).isPresent();
+        }
+
+        @DisplayName("해당 OAuth ID 를 가지지 않을 경우 Member 를 조회하지 못한다")
+        @Test
+        void notExist() {
+            final String oAuthId = "oauthID";
+
+            final Optional<Member> savedMember = memberRepository.findByOauthId(oAuthId);
+
+            assertThat(savedMember).isEmpty();
+        }
+    }
+}

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/AuthServiceTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/AuthServiceTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.dobugs.yologaauthenticationapi.repository.MemberRepository;
 import com.dobugs.yologaauthenticationapi.repository.OAuthRepository;
 import com.dobugs.yologaauthenticationapi.service.dto.request.OAuthRequest;
 import com.dobugs.yologaauthenticationapi.service.dto.response.OAuthLinkResponse;
@@ -28,10 +29,13 @@ class AuthServiceTest {
     @Mock
     private OAuthRepository oAuthRepository;
 
+    @Mock
+    private MemberRepository memberRepository;
+
     @BeforeEach
     void setUp() {
         final OAuthConnector connector = new FakeConnector();
-        authService = new AuthService(connector, connector, oAuthRepository);
+        authService = new AuthService(connector, connector, oAuthRepository, memberRepository);
     }
 
     @DisplayName("OAuth URL 생성 테스트")

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/FakeConnector.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/FakeConnector.java
@@ -3,6 +3,7 @@ package com.dobugs.yologaauthenticationapi.service;
 import com.dobugs.yologaauthenticationapi.support.OAuthConnector;
 import com.dobugs.yologaauthenticationapi.support.OAuthProvider;
 import com.dobugs.yologaauthenticationapi.support.dto.response.TokenResponse;
+import com.dobugs.yologaauthenticationapi.support.dto.response.UserResponse;
 
 public class FakeConnector implements OAuthConnector {
 
@@ -15,6 +16,11 @@ public class FakeConnector implements OAuthConnector {
 
     @Override
     public TokenResponse requestToken(final String authorizationCode, final String redirectUrl) {
+        return null;
+    }
+
+    @Override
+    public UserResponse requestUserInfo(final String tokenType, final String accessToken) {
         return null;
     }
 }

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/FakeProvider.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/FakeProvider.java
@@ -14,6 +14,7 @@ public class FakeProvider implements OAuthProvider {
     private static final String SCOPE = "scope";
     private static final String AUTH_URL = "authUrl";
     private static final String TOKEN_URL = "tokenUrl";
+    private static final String USER_INFO_URL = "userInfoUrl";
 
     @Override
     public String generateOAuthUrl(final String redirectUrl, final String referrer) {
@@ -35,7 +36,17 @@ public class FakeProvider implements OAuthProvider {
     }
 
     @Override
-    public HttpEntity<MultiValueMap<String, String>> createEntity() {
+    public String generateUserInfoUrl() {
+        return USER_INFO_URL;
+    }
+
+    @Override
+    public HttpEntity<MultiValueMap<String, String>> createTokenEntity() {
+        return null;
+    }
+
+    @Override
+    public HttpEntity<MultiValueMap<String, String>> createUserEntity(final String tokenType, final String accessToken) {
         return null;
     }
 }


### PR DESCRIPTION
## *관련 작업 티켓

- https://dobugs.atlassian.net/browse/YOL-118

## *작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- 구글과 카카오에서 조회한 Access Token 으로 사용자 정보를 조회하고, 이를 MySQL 에 저장합니다.
- 저장하는 사용자 정보는 구글과 카카오에서 공통적으로 보내주는 값인 OAuth ID 만을 저장합니다.

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)
