### PR TITLE
chore: rest docs api 문서 복사 과정 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,16 @@ asciidoctor.doFirst {
     delete file('src/main/resources/static/docs')
 }
 
+task copyDocument(type: Copy) {
+    dependsOn asciidoctor
+    from file("build/docs/asciidoc")
+    into file("src/main/resources/static/docs")
+}
+
+build {
+    dependsOn copyDocument
+}
+
 bootJar {
     dependsOn asciidoctor
 

--- a/build.gradle
+++ b/build.gradle
@@ -64,20 +64,17 @@ asciidoctor.doFirst {
     delete file('src/main/resources/static/docs')
 }
 
-task copyDocument(type: Copy) {
-    dependsOn asciidoctor
-    from file("build/docs/asciidoc")
-    into file("src/main/resources/static/docs")
-}
-
-build {
-    dependsOn copyDocument
-}
-
 bootJar {
     dependsOn asciidoctor
-    from ("${asciidoctor.outputDir}/html5") {
-        into 'static/docs'
+
+    copy {
+        from "${asciidoctor.outputDir}"
+        into 'src/main/resources/static/docs'
+    }
+
+    copy {
+        from file("src/main/resources/static")
+        into file("build/resources/main/static")
     }
 }
 /* RestDocs End */


### PR DESCRIPTION
## *관련 작업 티켓

- https://dobugs.atlassian.net/browse/YOL-133

## *작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- 로컬에서 build 시에는 문제가 없었으나 개발 서버에서 jar 파일 생성 후 실행하는 방식일 때에는 Rest Docs API 문서가 생성되지 않았습니다.
- 로컬에서 실행하는 명령어와 개발 서버에서 실행하는 명령어의 차이라고 판단하여 각 명령어별로 API 문서를 복사하는 작업을 추가하였습니다.
  - local : build
  - dev : bootJar

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)
