### PR TITLE
feat: 로그아웃 기능 구현

### DIFF
--- a/src/docs/asciidoc/auth.adoc
+++ b/src/docs/asciidoc/auth.adoc
@@ -22,3 +22,9 @@ Request
 include::{snippets}/auth/reissue/http-request.adoc[]
 Response
 include::{snippets}/auth/reissue/http-response.adoc[]
+
+== OAuth2.0 로그아웃
+Request
+include::{snippets}/auth/logout/http-request.adoc[]
+Response
+include::{snippets}/auth/logout/http-response.adoc[]

--- a/src/main/java/com/dobugs/yologaauthenticationapi/controller/AuthController.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/controller/AuthController.java
@@ -18,19 +18,19 @@ import com.dobugs.yologaauthenticationapi.service.dto.response.OAuthTokenRespons
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/oauth2")
 @RestController
 public class AuthController {
 
     private final AuthService authService;
 
-    @GetMapping("/oauth2/login")
+    @GetMapping("/login")
     public ResponseEntity<OAuthLinkResponse> generateOAuthUrl(@ModelAttribute final OAuthRequest request) {
         final OAuthLinkResponse response = authService.generateOAuthUrl(request);
         return ResponseEntity.ok(response);
     }
 
-    @PostMapping("/oauth2/login")
+    @PostMapping("/login")
     public ResponseEntity<OAuthTokenResponse> login(
         @ModelAttribute final OAuthRequest request,
         @RequestBody final OAuthCodeRequest codeRequest
@@ -39,9 +39,15 @@ public class AuthController {
         return ResponseEntity.ok(response);
     }
 
-    @PostMapping("/oauth2/reissue")
+    @PostMapping("/reissue")
     public ResponseEntity<OAuthTokenResponse> reissue(@RequestHeader("Authorization") final String refreshToken) {
         final OAuthTokenResponse response = authService.reissue(refreshToken);
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@RequestHeader("Authorization") final String accessToken) {
+        authService.logout(accessToken);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/repository/TokenRepository.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/repository/TokenRepository.java
@@ -45,6 +45,17 @@ public class TokenRepository {
         }
     }
 
+    public void delete(final Long memberId) {
+        operations.delete(String.valueOf(memberId),
+            OAuthToken.KEY_NAME_OF_PROVIDER, OAuthToken.KEY_NAME_OF_ACCESS_TOKEN, OAuthToken.KEY_NAME_OF_REFRESH_TOKEN
+        );
+    }
+
+    public boolean exist(final Long memberId) {
+        final String key = String.valueOf(memberId);
+        return operations.hasKey(key, OAuthToken.KEY_NAME_OF_REFRESH_TOKEN);
+    }
+
     public boolean existRefreshToken(final Long memberId, final String refreshToken) {
         final String key = String.valueOf(memberId);
         final String savedRefreshToken = (String) operations.get(key, OAuthToken.KEY_NAME_OF_REFRESH_TOKEN);

--- a/src/main/java/com/dobugs/yologaauthenticationapi/service/AuthService.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/service/AuthService.java
@@ -72,6 +72,15 @@ public class AuthService {
         return new OAuthTokenResponse(response.accessToken(), response.refreshToken());
     }
 
+    @Transactional
+    public void logout(final String serviceToken) {
+        final UserTokenResponse userTokenResponse = tokenGenerator.extract(serviceToken);
+        final Long memberId = userTokenResponse.memberId();
+
+        validateTheExistence(memberId);
+        tokenRepository.delete(memberId);
+    }
+
     private Long saveMember(final String provider, final TokenResponse tokenResponse, final UserResponse userResponse) {
         final Member savedMember = memberRepository.findByOauthId(userResponse.oAuthId())
             .orElseGet(() -> memberRepository.save(new Member(userResponse.oAuthId())));
@@ -85,14 +94,20 @@ public class AuthService {
         return savedMember.getId();
     }
 
+    private void restoreRefreshToken(final Long memberId, final String refreshToken) {
+        tokenRepository.saveRefreshToken(memberId, refreshToken);
+    }
+
+    private void validateTheExistence(final Long memberId) {
+        if (!tokenRepository.exist(memberId)) {
+            throw new IllegalArgumentException("로그인이 필요합니다.");
+        }
+    }
+
     private void validateTheExistenceOfRefreshToken(final Long memberId, final String refreshToken) {
         if (!tokenRepository.existRefreshToken(memberId, refreshToken)) {
             throw new IllegalArgumentException("잘못된 refresh token 입니다.");
         }
-    }
-
-    private void restoreRefreshToken(final Long memberId, final String refreshToken) {
-        tokenRepository.saveRefreshToken(memberId, refreshToken);
     }
 
     private OAuthConnector selectConnector(final String provider) {

--- a/src/main/java/com/dobugs/yologaauthenticationapi/service/AuthService.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/service/AuthService.java
@@ -77,7 +77,7 @@ public class AuthService {
         final UserTokenResponse userTokenResponse = tokenGenerator.extract(serviceToken);
         final Long memberId = userTokenResponse.memberId();
 
-        validateTheExistence(memberId);
+        validateLogged(memberId);
         tokenRepository.delete(memberId);
     }
 
@@ -98,13 +98,14 @@ public class AuthService {
         tokenRepository.saveRefreshToken(memberId, refreshToken);
     }
 
-    private void validateTheExistence(final Long memberId) {
+    private void validateLogged(final Long memberId) {
         if (!tokenRepository.exist(memberId)) {
-            throw new IllegalArgumentException("로그인이 필요합니다.");
+            throw new IllegalArgumentException(String.format("로그인이 필요합니다. [%d]", memberId));
         }
     }
 
     private void validateTheExistenceOfRefreshToken(final Long memberId, final String refreshToken) {
+        validateLogged(memberId);
         if (!tokenRepository.existRefreshToken(memberId, refreshToken)) {
             throw new IllegalArgumentException("잘못된 refresh token 입니다.");
         }

--- a/src/test/java/com/dobugs/yologaauthenticationapi/controller/AuthControllerTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/controller/AuthControllerTest.java
@@ -38,7 +38,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @DisplayName("Auth 컨트롤러 테스트")
 class AuthControllerTest {
 
-    private static final String BASIC_URL = "/api/v1";
+    private static final String BASIC_URL = "/api/v1/oauth2";
 
     @Autowired
     private MockMvc mockMvc;
@@ -62,7 +62,7 @@ class AuthControllerTest {
         final OAuthLinkResponse response = new OAuthLinkResponse(redirectUrl);
         given(authService.generateOAuthUrl(any())).willReturn(response);
 
-        mockMvc.perform(get(BASIC_URL + "/oauth2/login")
+        mockMvc.perform(get(BASIC_URL + "/login")
                 .params(params))
             .andExpect(status().isOk())
             .andDo(document(
@@ -89,7 +89,7 @@ class AuthControllerTest {
         final OAuthTokenResponse response = new OAuthTokenResponse("accessToken", "refreshToken");
         given(authService.login(any(), any())).willReturn(response);
 
-        mockMvc.perform(post(BASIC_URL + "/oauth2/login")
+        mockMvc.perform(post(BASIC_URL + "/login")
                 .params(params)
                 .content(body)
                 .contentType(MediaType.APPLICATION_JSON))
@@ -111,11 +111,27 @@ class AuthControllerTest {
         final OAuthTokenResponse response = new OAuthTokenResponse(accessToken, refreshToken);
         given(authService.reissue(refreshToken)).willReturn(response);
 
-        mockMvc.perform(post(BASIC_URL + "/oauth2/reissue")
+        mockMvc.perform(post(BASIC_URL + "/reissue")
                 .header("Authorization", refreshToken))
             .andExpect(status().isOk())
             .andDo(document(
                 "auth/reissue",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()))
+            )
+        ;
+    }
+
+    @DisplayName("로그아웃한다")
+    @Test
+    void logout() throws Exception {
+        final String accessToken = "accessToken";
+
+        mockMvc.perform(post(BASIC_URL + "/logout")
+                .header("Authorization", accessToken))
+            .andExpect(status().isOk())
+            .andDo(document(
+                "auth/logout",
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()))
             )

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/AuthServiceTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/AuthServiceTest.java
@@ -99,12 +99,12 @@ class AuthServiceTest {
 
             given(tokenGenerator.extract(serviceToken))
                 .willReturn(new UserTokenResponse(notExistMemberId, PROVIDER, existRefreshToken));
-            given(tokenRepository.existRefreshToken(notExistMemberId, existRefreshToken))
+            given(tokenRepository.exist(notExistMemberId))
                 .willReturn(false);
 
             assertThatThrownBy(() -> authService.reissue(serviceToken))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("잘못된 refresh token 입니다.");
+                .hasMessageContaining("로그인이 필요합니다.");
         }
 
         @DisplayName("refresh token 이 일치하지 않을 경우 예외가 발생한다")
@@ -116,6 +116,8 @@ class AuthServiceTest {
 
             given(tokenGenerator.extract(serviceToken))
                 .willReturn(new UserTokenResponse(existMemberId, PROVIDER, notExistRefreshToken));
+            given(tokenRepository.exist(existMemberId))
+                .willReturn(true);
             given(tokenRepository.existRefreshToken(existMemberId, notExistRefreshToken))
                 .willReturn(false);
 
@@ -135,7 +137,7 @@ class AuthServiceTest {
 
     @DisplayName("로그아웃 시 로그인 여부 검증 테스트")
     @Nested
-    public class validateTheExistence {
+    public class validateLogged {
 
         @DisplayName("memberId 가 존재하지 않을 경우 예외가 발생한다")
         @Test

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/AuthServiceTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/AuthServiceTest.java
@@ -132,4 +132,35 @@ class AuthServiceTest {
                 .compact();
         }
     }
+
+    @DisplayName("로그아웃 시 로그인 여부 검증 테스트")
+    @Nested
+    public class validateTheExistence {
+
+        @DisplayName("memberId 가 존재하지 않을 경우 예외가 발생한다")
+        @Test
+        void notExistMemberId() {
+            final long notExistMemberId = 0L;
+            final String provider = "google";
+            final String refreshToken = "refreshToken";
+            final String serviceToken = createToken(notExistMemberId, provider, refreshToken);
+
+            given(tokenGenerator.extract(serviceToken))
+                .willReturn(new UserTokenResponse(notExistMemberId, provider, refreshToken));
+            given(tokenRepository.exist(notExistMemberId))
+                .willReturn(false);
+
+            assertThatThrownBy(() -> authService.logout(serviceToken))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("로그인이 필요합니다.");
+        }
+
+        private String createToken(final Long memberId, final String provider, final String token) {
+            return Jwts.builder()
+                .claim("memberId", memberId)
+                .claim("provider", provider)
+                .claim("token", token)
+                .compact();
+        }
+    }
 }


### PR DESCRIPTION
## *관련 작업 티켓

- https://dobugs.atlassian.net/browse/YOL-125

## *작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- 로그아웃 기능 구현을 blacklist 로 구현하려 했으나 그럴 필요성을 느끼지 못해 로그아웃 할 경우 데이터를 삭제하는 방식으로 변경하였습니다.
  - blacklist 방식
    - 로그인 - refresh token 존재
    - 로그아웃 - access token 존재
- 로그인 요청 시 이전에 로그인 되었는지에 대한 여부를 검증하는 것은 불필요하다고 생각하여 추가하지 않았습니다.
  - 로그인 되어 있는 상태에서 로그인 요청 시 데이터를 덮어쓰며 저장됨

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)
