### PR TITLE
feat: 사용자 정보 조회, 내 정보 조회, 수정, 탈퇴하기 기능 구현

### DIFF
--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -16,3 +16,9 @@ Request
 include::{snippets}/member/find-me/http-request.adoc[]
 Response
 include::{snippets}/member/find-me/http-response.adoc[]
+
+== 내 정보 수정
+Request
+include::{snippets}/member/update/http-request.adoc[]
+Response
+include::{snippets}/member/update/http-response.adoc[]

--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -10,3 +10,9 @@ Request
 include::{snippets}/member/find-by-id/http-request.adoc[]
 Response
 include::{snippets}/member/find-by-id/http-response.adoc[]
+
+== 내 정보 조회
+Request
+include::{snippets}/member/find-me/http-request.adoc[]
+Response
+include::{snippets}/member/find-me/http-response.adoc[]

--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -22,3 +22,9 @@ Request
 include::{snippets}/member/update/http-request.adoc[]
 Response
 include::{snippets}/member/update/http-response.adoc[]
+
+== 탈퇴하기
+Request
+include::{snippets}/member/delete/http-request.adoc[]
+Response
+include::{snippets}/member/delete/http-response.adoc[]

--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -1,0 +1,12 @@
+= 사용자 API
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+
+== 사용자 정보 조회
+Request
+include::{snippets}/member/find-by-id/http-request.adoc[]
+Response
+include::{snippets}/member/find-by-id/http-response.adoc[]

--- a/src/main/java/com/dobugs/yologaauthenticationapi/controller/MemberController.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.dobugs.yologaauthenticationapi.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -39,6 +40,12 @@ public class MemberController {
         final MemberUpdateRequest request
     ) {
         memberService.update(accessToken, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> delete(@RequestHeader("Authorization") final String accessToken) {
+        memberService.delete(accessToken);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/controller/MemberController.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/controller/MemberController.java
@@ -3,6 +3,7 @@ package com.dobugs.yologaauthenticationapi.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,6 +22,12 @@ public class MemberController {
     @GetMapping("/{memberId}")
     public ResponseEntity<MemberResponse> findById(@PathVariable final Long memberId) {
         final MemberResponse response = memberService.findById(memberId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<MemberResponse> findMe(@RequestHeader("Authorization") final String accessToken) {
+        final MemberResponse response = memberService.findMe(accessToken);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/controller/MemberController.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/controller/MemberController.java
@@ -1,0 +1,26 @@
+package com.dobugs.yologaauthenticationapi.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.dobugs.yologaauthenticationapi.service.MemberService;
+import com.dobugs.yologaauthenticationapi.service.dto.response.MemberResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/members")
+@RestController
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/{memberId}")
+    public ResponseEntity<MemberResponse> findById(@PathVariable final Long memberId) {
+        final MemberResponse response = memberService.findById(memberId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/dobugs/yologaauthenticationapi/controller/MemberController.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/controller/MemberController.java
@@ -3,11 +3,13 @@ package com.dobugs.yologaauthenticationapi.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.dobugs.yologaauthenticationapi.service.MemberService;
+import com.dobugs.yologaauthenticationapi.service.dto.request.MemberUpdateRequest;
 import com.dobugs.yologaauthenticationapi.service.dto.response.MemberResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -29,5 +31,14 @@ public class MemberController {
     public ResponseEntity<MemberResponse> findMe(@RequestHeader("Authorization") final String accessToken) {
         final MemberResponse response = memberService.findMe(accessToken);
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> update(
+        @RequestHeader("Authorization") final String accessToken,
+        final MemberUpdateRequest request
+    ) {
+        memberService.update(accessToken, request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/domain/BaseEntity.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/domain/BaseEntity.java
@@ -9,7 +9,9 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
 
+@Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {

--- a/src/main/java/com/dobugs/yologaauthenticationapi/domain/Member.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/domain/Member.java
@@ -1,5 +1,7 @@
 package com.dobugs.yologaauthenticationapi.domain;
 
+import java.util.regex.Pattern;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -14,6 +16,10 @@ import lombok.NoArgsConstructor;
 @Entity
 public class Member extends BaseEntity {
 
+    private static final Pattern PHONE_NUMBER_PATTERN = Pattern.compile("^\\d{3}-\\d{3,4}-\\d{4}$");
+    private static final int NICKNAME_LENGTH = 50;
+    private static final int PHONE_NUMBER_LENGTH = 50;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -21,10 +27,10 @@ public class Member extends BaseEntity {
     @Column(nullable = false)
     private String oauthId;
 
-    @Column
+    @Column(length = NICKNAME_LENGTH)
     private String nickname;
 
-    @Column
+    @Column(length = PHONE_NUMBER_LENGTH)
     private String phoneNumber;
 
     @Column
@@ -32,5 +38,24 @@ public class Member extends BaseEntity {
 
     public Member(final String oauthId) {
         this.oauthId = oauthId;
+    }
+
+    public void update(final String nickname, final String phoneNumber) {
+        validateNickname(nickname);
+        validatePhoneNumber(phoneNumber);
+        this.nickname = nickname;
+        this.phoneNumber = phoneNumber;
+    }
+
+    private void validateNickname(final String nickname) {
+        if (nickname.length() > NICKNAME_LENGTH) {
+            throw new IllegalArgumentException(String.format("닉네임은 %d자 이하여야 합니다. [%s]", NICKNAME_LENGTH, nickname));
+        }
+    }
+
+    private void validatePhoneNumber(final String phoneNumber) {
+        if (!PHONE_NUMBER_PATTERN.matcher(phoneNumber).matches()) {
+            throw new IllegalArgumentException(String.format("올바른 전화번호 형식이 아닙니다. [%s]", phoneNumber));
+        }
     }
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/domain/Member.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/domain/Member.java
@@ -25,6 +25,9 @@ public class Member extends BaseEntity {
     private String nickname;
 
     @Column
+    private String phoneNumber;
+
+    @Column
     private int resourceId;
 
     public Member(final String oauthId) {

--- a/src/main/java/com/dobugs/yologaauthenticationapi/repository/MemberRepository.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/repository/MemberRepository.java
@@ -9,4 +9,6 @@ import com.dobugs.yologaauthenticationapi.domain.Member;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByOauthId(String oauthId);
+
+    Optional<Member> findByIdAndArchivedIsTrue(Long memberId);
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/service/MemberService.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/service/MemberService.java
@@ -6,6 +6,8 @@ import org.springframework.transaction.annotation.Transactional;
 import com.dobugs.yologaauthenticationapi.domain.Member;
 import com.dobugs.yologaauthenticationapi.repository.MemberRepository;
 import com.dobugs.yologaauthenticationapi.service.dto.response.MemberResponse;
+import com.dobugs.yologaauthenticationapi.support.TokenGenerator;
+import com.dobugs.yologaauthenticationapi.support.dto.response.UserTokenResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -15,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final TokenGenerator tokenGenerator;
 
     public MemberResponse findById(final Long memberId) {
         final Member savedMember = memberRepository.findById(memberId)
@@ -26,5 +29,11 @@ public class MemberService {
             savedMember.getPhoneNumber(),
             String.valueOf(savedMember.getResourceId())
         );
+    }
+
+    public MemberResponse findMe(final String serviceToken) {
+        final UserTokenResponse userTokenResponse = tokenGenerator.extract(serviceToken);
+        final Long memberId = userTokenResponse.memberId();
+        return findById(memberId);
     }
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/service/MemberService.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/service/MemberService.java
@@ -5,6 +5,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.dobugs.yologaauthenticationapi.domain.Member;
 import com.dobugs.yologaauthenticationapi.repository.MemberRepository;
+import com.dobugs.yologaauthenticationapi.service.dto.request.MemberUpdateRequest;
 import com.dobugs.yologaauthenticationapi.service.dto.response.MemberResponse;
 import com.dobugs.yologaauthenticationapi.support.TokenGenerator;
 import com.dobugs.yologaauthenticationapi.support.dto.response.UserTokenResponse;
@@ -20,8 +21,7 @@ public class MemberService {
     private final TokenGenerator tokenGenerator;
 
     public MemberResponse findById(final Long memberId) {
-        final Member savedMember = memberRepository.findById(memberId)
-            .orElseThrow(() -> new IllegalArgumentException(String.format("존재하지 않는 사용자입니다. [%d]", memberId)));
+        final Member savedMember = findMemberById(memberId);
         return new MemberResponse(
             savedMember.getId(),
             savedMember.getOauthId(),
@@ -35,5 +35,18 @@ public class MemberService {
         final UserTokenResponse userTokenResponse = tokenGenerator.extract(serviceToken);
         final Long memberId = userTokenResponse.memberId();
         return findById(memberId);
+    }
+
+    @Transactional
+    public void update(final String serviceToken, final MemberUpdateRequest request) {
+        final UserTokenResponse userTokenResponse = tokenGenerator.extract(serviceToken);
+        final Long memberId = userTokenResponse.memberId();
+        final Member savedMember = findMemberById(memberId);
+        savedMember.update(request.nickname(), request.phoneNumber());
+    }
+
+    private Member findMemberById(final Long memberId) {
+        return memberRepository.findById(memberId)
+            .orElseThrow(() -> new IllegalArgumentException(String.format("존재하지 않는 사용자입니다. [%d]", memberId)));
     }
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/service/MemberService.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/service/MemberService.java
@@ -45,8 +45,16 @@ public class MemberService {
         savedMember.update(request.nickname(), request.phoneNumber());
     }
 
+    @Transactional
+    public void delete(final String serviceToken) {
+        final UserTokenResponse userTokenResponse = tokenGenerator.extract(serviceToken);
+        final Long memberId = userTokenResponse.memberId();
+        final Member savedMember = findMemberById(memberId);
+        savedMember.delete();
+    }
+
     private Member findMemberById(final Long memberId) {
-        return memberRepository.findById(memberId)
+        return memberRepository.findByIdAndArchivedIsTrue(memberId)
             .orElseThrow(() -> new IllegalArgumentException(String.format("존재하지 않는 사용자입니다. [%d]", memberId)));
     }
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/service/MemberService.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/service/MemberService.java
@@ -1,0 +1,30 @@
+package com.dobugs.yologaauthenticationapi.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.dobugs.yologaauthenticationapi.domain.Member;
+import com.dobugs.yologaauthenticationapi.repository.MemberRepository;
+import com.dobugs.yologaauthenticationapi.service.dto.response.MemberResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public MemberResponse findById(final Long memberId) {
+        final Member savedMember = memberRepository.findById(memberId)
+            .orElseThrow(() -> new IllegalArgumentException(String.format("존재하지 않는 사용자입니다. [%d]", memberId)));
+        return new MemberResponse(
+            savedMember.getId(),
+            savedMember.getOauthId(),
+            savedMember.getNickname(),
+            savedMember.getPhoneNumber(),
+            String.valueOf(savedMember.getResourceId())
+        );
+    }
+}

--- a/src/main/java/com/dobugs/yologaauthenticationapi/service/dto/request/MemberUpdateRequest.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/service/dto/request/MemberUpdateRequest.java
@@ -1,0 +1,4 @@
+package com.dobugs.yologaauthenticationapi.service.dto.request;
+
+public record MemberUpdateRequest(String nickname, String phoneNumber) {
+}

--- a/src/main/java/com/dobugs/yologaauthenticationapi/service/dto/response/MemberResponse.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/service/dto/response/MemberResponse.java
@@ -1,0 +1,4 @@
+package com.dobugs.yologaauthenticationapi.service.dto.response;
+
+public record MemberResponse(Long id, String oauthId, String nickname, String phoneNumber, String profileUrl) {
+}

--- a/src/test/java/com/dobugs/yologaauthenticationapi/controller/MemberControllerTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/controller/MemberControllerTest.java
@@ -1,0 +1,61 @@
+package com.dobugs.yologaauthenticationapi.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.dobugs.yologaauthenticationapi.service.MemberService;
+import com.dobugs.yologaauthenticationapi.service.dto.response.MemberResponse;
+
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs
+@WebMvcTest(MemberController.class)
+@ExtendWith({RestDocumentationExtension.class, MockitoExtension.class})
+@DisplayName("Member 컨트롤러 테스트")
+class MemberControllerTest {
+
+    private static final String BASIC_URL = "/api/v1/members";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MemberService memberService;
+
+    @DisplayName("사용자 아이디를 이용하여 사용자 정보를 조회한다")
+    @Test
+    void findById() throws Exception {
+        final long memberId = 0L;
+
+        final MemberResponse response = new MemberResponse(
+            memberId, "0123456789", "유콩", "010-0000-0000",
+            "https://lh3.googleusercontent.com/a/AEdFTp6-48aO-w67aAJcYb22G0BLTvY23z4uMBb1Nec=s96-c"
+        );
+        given(memberService.findById(memberId)).willReturn(response);
+
+        mockMvc.perform(get(BASIC_URL + "/" + memberId))
+            .andExpect(status().isOk())
+            .andDo(document(
+                "member/find-by-id",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()))
+            )
+        ;
+    }
+}

--- a/src/test/java/com/dobugs/yologaauthenticationapi/controller/MemberControllerTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/controller/MemberControllerTest.java
@@ -3,6 +3,7 @@ package com.dobugs.yologaauthenticationapi.controller;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
@@ -17,11 +18,14 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.dobugs.yologaauthenticationapi.service.MemberService;
+import com.dobugs.yologaauthenticationapi.service.dto.request.MemberUpdateRequest;
 import com.dobugs.yologaauthenticationapi.service.dto.response.MemberResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @AutoConfigureMockMvc
 @AutoConfigureRestDocs
@@ -34,6 +38,9 @@ class MemberControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @MockBean
     private MemberService memberService;
@@ -75,6 +82,27 @@ class MemberControllerTest {
             .andExpect(status().isOk())
             .andDo(document(
                 "member/find-me",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()))
+            )
+        ;
+    }
+
+    @DisplayName("내 정보를 수정한다")
+    @Test
+    void update() throws Exception {
+        final String accessToken = "accessToken";
+
+        final MemberUpdateRequest request = new MemberUpdateRequest("유콩", "010-0000-0000");
+        final String body = objectMapper.writeValueAsString(request);
+
+        mockMvc.perform(post(BASIC_URL)
+                .header("Authorization", accessToken)
+                .content(body)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andDo(document(
+                "member/update",
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()))
             )

--- a/src/test/java/com/dobugs/yologaauthenticationapi/controller/MemberControllerTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/controller/MemberControllerTest.java
@@ -2,6 +2,7 @@ package com.dobugs.yologaauthenticationapi.controller;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
@@ -103,6 +104,22 @@ class MemberControllerTest {
             .andExpect(status().isOk())
             .andDo(document(
                 "member/update",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()))
+            )
+        ;
+    }
+
+    @DisplayName("탈퇴한다")
+    @Test
+    void deleteMember() throws Exception {
+        final String accessToken = "accessToken";
+
+        mockMvc.perform(delete(BASIC_URL)
+                .header("Authorization", accessToken))
+            .andExpect(status().isOk())
+            .andDo(document(
+                "member/delete",
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()))
             )

--- a/src/test/java/com/dobugs/yologaauthenticationapi/controller/MemberControllerTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/controller/MemberControllerTest.java
@@ -58,4 +58,26 @@ class MemberControllerTest {
             )
         ;
     }
+
+    @DisplayName("JWT 를 이용하여 내 정보를 조회한다")
+    @Test
+    void findMe() throws Exception {
+        final String accessToken = "accessToken";
+
+        final MemberResponse response = new MemberResponse(
+            0L, "0123456789", "유콩", "010-0000-0000",
+            "https://lh3.googleusercontent.com/a/AEdFTp6-48aO-w67aAJcYb22G0BLTvY23z4uMBb1Nec=s96-c"
+        );
+        given(memberService.findMe(accessToken)).willReturn(response);
+
+        mockMvc.perform(get(BASIC_URL + "/me")
+                .header("Authorization", accessToken))
+            .andExpect(status().isOk())
+            .andDo(document(
+                "member/find-me",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()))
+            )
+        ;
+    }
 }

--- a/src/test/java/com/dobugs/yologaauthenticationapi/domain/MemberTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/domain/MemberTest.java
@@ -1,0 +1,63 @@
+package com.dobugs.yologaauthenticationapi.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Member 도메인 테스트")
+class MemberTest {
+
+    @DisplayName("사용자 수정 테스트")
+    @Nested
+    public class update {
+
+        private Member member;
+
+        @BeforeEach
+        void setUp() {
+            member = new Member("oauthId");
+        }
+
+        @DisplayName("사용자 정보를 수정한다")
+        @Test
+        void success() {
+            final String nickname = "유콩";
+            final String phoneNumber = "010-0000-0000";
+
+            member.update(nickname, phoneNumber);
+
+            assertAll(
+                () -> assertThat(member.getNickname()).isEqualTo(nickname),
+                () -> assertThat(member.getPhoneNumber()).isEqualTo(phoneNumber)
+            );
+        }
+
+        @DisplayName("닉네임이 50자 이상일 경우 예외가 발생한다")
+        @Test
+        void nicknameLengthIsOver50() {
+            final String invalidNickname = "유콩".repeat(50);
+            final String phoneNumber = "010-0000-0000";
+
+            assertThatThrownBy(() -> member.update(invalidNickname, phoneNumber))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("닉네임은")
+                .hasMessageContaining("자 이하여야 합니다.");
+        }
+
+        @DisplayName("전화번호가 올바른 형식이 아닐 경우 예외가 발생한다")
+        @Test
+        void phoneNumberFormatIsNotValid() {
+            final String nickname = "유콩";
+            final String invalidPhoneNumber = "0123456789";
+
+            assertThatThrownBy(() -> member.update(nickname, invalidPhoneNumber))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("올바른 전화번호 형식이 아닙니다.");
+        }
+    }
+}

--- a/src/test/java/com/dobugs/yologaauthenticationapi/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/repository/MemberRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.dobugs.yologaauthenticationapi.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.util.Optional;
 
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
 import com.dobugs.yologaauthenticationapi.domain.Member;
 
@@ -20,6 +22,9 @@ class MemberRepositoryTest {
 
     @Autowired
     private MemberRepository memberRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
 
     @DisplayName("OAuth ID 를 이용하여 Member 를 조회하는 테스트")
     @Nested
@@ -45,6 +50,47 @@ class MemberRepositoryTest {
             final Optional<Member> savedMember = memberRepository.findByOauthId(oAuthId);
 
             assertThat(savedMember).isEmpty();
+        }
+    }
+
+    @DisplayName("사용자 아이디를 이용하여 사용자 정보를 조회하는 테스트")
+    @Nested
+    public class findByIdAndArchivedIsTrue {
+
+        @DisplayName("archived 가 true 일 경우 Member 를 조회한다")
+        @Test
+        void success() {
+            final Member member = new Member("oauthId");
+            final Member savedMember = memberRepository.save(member);
+
+            final Optional<Member> expected = memberRepository.findByIdAndArchivedIsTrue(savedMember.getId());
+
+            assertThat(expected).isPresent();
+        }
+
+        @DisplayName("archived 가 false 일 경우 Member 를 조회하지 못한다")
+        @Test
+        void fail() {
+            final Member member = new Member("oauthId");
+            final Member savedMember = memberRepository.save(member);
+            member.delete();
+            entityManager.flush();
+
+            assertAll(
+                () -> assertThat(memberRepository.findById(savedMember.getId())).isPresent(),
+                () -> assertThat(memberRepository.findByIdAndArchivedIsTrue(savedMember.getId())).isEmpty()
+            );
+        }
+
+        @DisplayName("Member 가 존재하지 않을 경우 Member 를 조회하지 못한다")
+        @Test
+        void notExist() {
+            final long memberId = 0L;
+
+            assertAll(
+                () -> assertThat(memberRepository.findById(memberId)).isEmpty(),
+                () -> assertThat(memberRepository.findByIdAndArchivedIsTrue(memberId)).isEmpty()
+            );
         }
     }
 }

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/MemberServiceTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/MemberServiceTest.java
@@ -1,0 +1,66 @@
+package com.dobugs.yologaauthenticationapi.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.dobugs.yologaauthenticationapi.domain.Member;
+import com.dobugs.yologaauthenticationapi.repository.MemberRepository;
+import com.dobugs.yologaauthenticationapi.service.dto.response.MemberResponse;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Member 서비스 테스트")
+class MemberServiceTest {
+
+    private MemberService memberService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @BeforeEach
+    void setUp() {
+        memberService = new MemberService(memberRepository);
+    }
+
+    @DisplayName("사용자 아이디를 이용하여 사용자 정보 조회 테스트")
+    @Nested
+    public class findById {
+
+        @DisplayName("사용자의 아이디를 이용하여 사용자 정보를 조회한다")
+        @Test
+        void success() {
+            final long memberId = 0L;
+
+            final Member member = mock(Member.class);
+            given(member.getId()).willReturn(memberId);
+
+            final Optional<Member> savedMember = Optional.of(member);
+            given(memberRepository.findById(memberId))
+                .willReturn(savedMember);
+
+            final MemberResponse response = memberService.findById(memberId);
+            assertThat(response.id()).isEqualTo(memberId);
+        }
+
+        @DisplayName("존재하지 않는 사용자를 조회하면 예외가 발생한다")
+        @Test
+        void fail() {
+            final long memberId = 0L;
+
+            assertThatThrownBy(() -> memberService.findById(memberId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("존재하지 않는 사용자입니다.");
+        }
+    }
+}

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/MemberServiceTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/MemberServiceTest.java
@@ -16,8 +16,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.dobugs.yologaauthenticationapi.domain.Member;
+import com.dobugs.yologaauthenticationapi.domain.Provider;
 import com.dobugs.yologaauthenticationapi.repository.MemberRepository;
 import com.dobugs.yologaauthenticationapi.service.dto.response.MemberResponse;
+import com.dobugs.yologaauthenticationapi.support.TokenGenerator;
+import com.dobugs.yologaauthenticationapi.support.dto.response.UserTokenResponse;
+
+import io.jsonwebtoken.Jwts;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("Member 서비스 테스트")
@@ -28,12 +33,15 @@ class MemberServiceTest {
     @Mock
     private MemberRepository memberRepository;
 
+    @Mock
+    private TokenGenerator tokenGenerator;
+
     @BeforeEach
     void setUp() {
-        memberService = new MemberService(memberRepository);
+        memberService = new MemberService(memberRepository, tokenGenerator);
     }
 
-    @DisplayName("사용자 아이디를 이용하여 사용자 정보 조회 테스트")
+    @DisplayName("사용자 정보 조회 테스트")
     @Nested
     public class findById {
 
@@ -43,11 +51,9 @@ class MemberServiceTest {
             final long memberId = 0L;
 
             final Member member = mock(Member.class);
-            given(member.getId()).willReturn(memberId);
-
             final Optional<Member> savedMember = Optional.of(member);
-            given(memberRepository.findById(memberId))
-                .willReturn(savedMember);
+            given(member.getId()).willReturn(memberId);
+            given(memberRepository.findById(memberId)).willReturn(savedMember);
 
             final MemberResponse response = memberService.findById(memberId);
             assertThat(response.id()).isEqualTo(memberId);
@@ -61,6 +67,49 @@ class MemberServiceTest {
             assertThatThrownBy(() -> memberService.findById(memberId))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("존재하지 않는 사용자입니다.");
+        }
+    }
+
+    @DisplayName("내 정보 조회 테스트")
+    @Nested
+    public class findMe {
+
+        private static final Long MEMBER_ID = 0L;
+        private static final String PROVIDER = Provider.GOOGLE.getName();
+        private static final String ACCESS_TOKEN = "accessToken";
+
+        @DisplayName("JWT 를 이용하여 사용자 정보를 조회한다")
+        @Test
+        void success() {
+            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+
+            final Member member = mock(Member.class);
+            final Optional<Member> savedMember = Optional.of(member);
+            given(member.getId()).willReturn(MEMBER_ID);
+            given(memberRepository.findById(MEMBER_ID)).willReturn(savedMember);
+
+            final MemberResponse response = memberService.findMe(serviceToken);
+            assertThat(response.id()).isEqualTo(MEMBER_ID);
+        }
+
+        @DisplayName("존재하지 않는 사용자를 조회하면 예외가 발생한다")
+        @Test
+        void fail() {
+            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+
+            assertThatThrownBy(() -> memberService.findMe(serviceToken))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("존재하지 않는 사용자입니다.");
+        }
+
+        private String createToken(final Long memberId, final String provider, final String token) {
+            return Jwts.builder()
+                .claim("memberId", memberId)
+                .claim("provider", provider)
+                .claim("token", token)
+                .compact();
         }
     }
 }

--- a/src/test/java/com/dobugs/yologaauthenticationapi/support/TokenGeneratorTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/support/TokenGeneratorTest.java
@@ -1,9 +1,11 @@
 package com.dobugs.yologaauthenticationapi.support;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Date;
 
 import javax.crypto.SecretKey;
 
@@ -12,10 +14,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import com.dobugs.yologaauthenticationapi.domain.Provider;
 import com.dobugs.yologaauthenticationapi.support.dto.response.TokenResponse;
 import com.dobugs.yologaauthenticationapi.support.dto.response.ServiceTokenResponse;
+import com.dobugs.yologaauthenticationapi.support.dto.response.UserTokenResponse;
 
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 
 class TokenGeneratorTest {
@@ -36,7 +41,7 @@ class TokenGeneratorTest {
     public class create {
 
         private static final long MEMBER_ID = 0L;
-        private static final String PROVIDER = "google";
+        private static final String PROVIDER = Provider.GOOGLE.getName();
         private static final String ACCESS_TOKEN = "accessToken";
         private static final String REFRESH_TOKEN = "refreshToken";
         private static final int EXPIRES_IN = 1000;
@@ -85,6 +90,51 @@ class TokenGeneratorTest {
                 .parseClaimsJws(createdToken)
                 .getBody()
                 .get("provider");
+        }
+    }
+
+    @DisplayName("토큰 추출 테스트")
+    @Nested
+    public class extract {
+
+        private static final long MEMBER_ID = 0L;
+        private static final String PROVIDER = Provider.GOOGLE.getName();
+        private static final String ACCESS_TOKEN = "accessToken";
+        private static final Date EXPIRATION = new Date(new Date().getTime() + 1000);
+
+        @DisplayName("token 을 추출한다")
+        @Test
+        void success() {
+            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN, EXPIRATION);
+
+            final UserTokenResponse userTokenResponse = tokenGenerator.extract(serviceToken);
+
+            assertAll(
+                () -> assertThat(userTokenResponse.memberId()).isEqualTo(MEMBER_ID),
+                () -> assertThat(userTokenResponse.token()).isEqualTo(ACCESS_TOKEN),
+                () -> assertThat(userTokenResponse.provider()).isEqualTo(PROVIDER)
+            );
+        }
+
+        @DisplayName("만료 시간이 지난 token 일 경우 예외가 발생한다")
+        @Test
+        void fail() {
+            final Date expiration = new Date(new Date().getTime() - 1);
+            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN, expiration);
+
+            assertThatThrownBy(() -> tokenGenerator.extract(serviceToken))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("토큰의 만료 시간이 지났습니다.");
+        }
+
+        private String createToken(final Long memberId, final String provider, final String token, final Date expiration) {
+            return Jwts.builder()
+                .claim("memberId", memberId)
+                .claim("provider", provider)
+                .claim("token", token)
+                .setExpiration(expiration)
+                .signWith(SECRET_KEY, SignatureAlgorithm.HS256)
+                .compact();
         }
     }
 }


### PR DESCRIPTION
## *관련 작업 티켓

- https://dobugs.atlassian.net/browse/YOL-126
- https://dobugs.atlassian.net/browse/YOL-127
- https://dobugs.atlassian.net/browse/YOL-128
- https://dobugs.atlassian.net/browse/YOL-129

## *작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- 사용자 정보와 관련된 기능들을 구현하였습니다.
  - 사용자 정보 조회
  - 내 정보 조회
  - 내 정보 수정
  - 탈퇴하기
- 사용자 프로필 관련 기능은 아직 구현되지 않았습니다. 따라서 사용자 정보 조회 시 `profileUrl` 은 추후에 만들어질 리소스 테이블의 아이디값이 반환됩니다.
- 탈퇴하기 요청 시 사용자의 데이터가 삭제되는 것이 아닌 `archived` 의 값이 `false` 로 변경됩니다.
- 토큰의 만료 시간 검증의 중복을 줄이기 위해 해당 과정은 `TokenGenerator` 에서 정의하였습니다.

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)
