### PR TITLE
feat: 사용자 생성 시 기본 닉네임 설정

### DIFF
--- a/src/main/java/com/dobugs/yologaauthenticationapi/domain/Member.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/domain/Member.java
@@ -19,6 +19,7 @@ public class Member extends BaseEntity {
     private static final Pattern PHONE_NUMBER_PATTERN = Pattern.compile("^\\d{3}-\\d{3,4}-\\d{4}$");
     private static final int NICKNAME_LENGTH = 50;
     private static final int PHONE_NUMBER_LENGTH = 50;
+    private static final String INITIAL_NICKNAME_PREFIX = "DOBUGS#";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -38,6 +39,10 @@ public class Member extends BaseEntity {
 
     public Member(final String oauthId) {
         this.oauthId = oauthId;
+    }
+
+    public void init() {
+        nickname = INITIAL_NICKNAME_PREFIX + id;
     }
 
     public void update(final String nickname, final String phoneNumber) {

--- a/src/main/java/com/dobugs/yologaauthenticationapi/service/AuthService.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/service/AuthService.java
@@ -83,7 +83,12 @@ public class AuthService {
 
     private Long saveMember(final String provider, final TokenResponse tokenResponse, final UserResponse userResponse) {
         final Member savedMember = memberRepository.findByOauthId(userResponse.oAuthId())
-            .orElseGet(() -> memberRepository.save(new Member(userResponse.oAuthId())));
+            .orElseGet(() -> {
+                final Member member = new Member(userResponse.oAuthId());
+                memberRepository.save(member);
+                member.init();
+                return member;
+            });
 
         final OAuthToken oAuthToken = OAuthToken.login(
             savedMember.getId(), Provider.findOf(provider),

--- a/src/test/java/com/dobugs/yologaauthenticationapi/domain/MemberTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/domain/MemberTest.java
@@ -12,6 +12,21 @@ import org.junit.jupiter.api.Test;
 @DisplayName("Member 도메인 테스트")
 class MemberTest {
 
+    @DisplayName("사용자 초기화 테스트")
+    @Nested
+    public class init {
+
+        @DisplayName("사용자 정보를 초기화한다")
+        @Test
+        void success() {
+            final Member member = new Member("oauthId");
+
+            member.init();
+
+            assertThat(member.getNickname()).contains("DOBUGS#");
+        }
+    }
+
     @DisplayName("사용자 수정 테스트")
     @Nested
     public class update {

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/AuthServiceTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/AuthServiceTest.java
@@ -1,23 +1,35 @@
 package com.dobugs.yologaauthenticationapi.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.dobugs.yologaauthenticationapi.domain.Member;
 import com.dobugs.yologaauthenticationapi.repository.MemberRepository;
 import com.dobugs.yologaauthenticationapi.repository.TokenRepository;
+import com.dobugs.yologaauthenticationapi.service.dto.request.OAuthCodeRequest;
 import com.dobugs.yologaauthenticationapi.service.dto.request.OAuthRequest;
 import com.dobugs.yologaauthenticationapi.service.dto.response.OAuthLinkResponse;
+import com.dobugs.yologaauthenticationapi.service.dto.response.OAuthTokenResponse;
 import com.dobugs.yologaauthenticationapi.support.OAuthConnector;
 import com.dobugs.yologaauthenticationapi.support.TokenGenerator;
+import com.dobugs.yologaauthenticationapi.support.dto.response.ServiceTokenResponse;
 import com.dobugs.yologaauthenticationapi.support.dto.response.UserTokenResponse;
 
 import io.jsonwebtoken.Jwts;
@@ -40,9 +52,11 @@ class AuthServiceTest {
     @Mock
     private TokenGenerator tokenGenerator;
 
+    private OAuthConnector connector;
+
     @BeforeEach
     void setUp() {
-        final OAuthConnector connector = new FakeConnector();
+        connector = new FakeConnector();
         authService = new AuthService(connector, connector, memberRepository, tokenRepository, tokenGenerator);
     }
 
@@ -50,21 +64,10 @@ class AuthServiceTest {
     @Nested
     public class generateOAuthTokenUrl {
 
-        @DisplayName("구글 OAuth URL 을 생성한다")
-        @Test
-        void generateGoogleOAuthUrl() {
-            final String provider = "google";
-            final OAuthRequest request = new OAuthRequest(provider, REDIRECT_URL, REFERRER_URL);
-
-            final OAuthLinkResponse response = authService.generateOAuthUrl(request);
-
-            assertThat(response.oauthLoginLink()).contains(REDIRECT_URL);
-        }
-
-        @DisplayName("카카오 OAuth URL 을 생성한다")
-        @Test
-        void generateKakaoOAuthUrl() {
-            final String provider = "kakao";
+        @DisplayName("OAuth URL 을 생성한다")
+        @ParameterizedTest
+        @ValueSource(strings = {"google", "kakao"})
+        void success(final String provider) {
             final OAuthRequest request = new OAuthRequest(provider, REDIRECT_URL, REFERRER_URL);
 
             final OAuthLinkResponse response = authService.generateOAuthUrl(request);
@@ -84,23 +87,107 @@ class AuthServiceTest {
         }
     }
 
-    @DisplayName("Access Token 재발급 시 Refresh Token 검증 테스트")
+    @DisplayName("로그인 테스트")
     @Nested
-    public class validateTheExistenceOfRefreshToken {
+    public class login {
 
-        private static final String PROVIDER = "google";
+        private static final String ACCESS_TOKEN = "accessToken";
+        private static final String REFRESH_TOKEN = "refreshToken";
+
+        @DisplayName("로그인한다")
+        @ParameterizedTest
+        @ValueSource(strings = {"google", "kakao"})
+        void success(final String provider) {
+            final OAuthRequest request = new OAuthRequest(provider, REDIRECT_URL, REFERRER_URL);
+            final OAuthCodeRequest codeRequest = new OAuthCodeRequest("authorizationCode");
+
+            given(memberRepository.findByOauthId(any())).willReturn(Optional.of(new Member("oauthId")));
+            given(tokenGenerator.create(any(), eq(provider), any())).willReturn(new ServiceTokenResponse(ACCESS_TOKEN, REFRESH_TOKEN));
+
+            final OAuthTokenResponse response = authService.login(request, codeRequest);
+
+            assertAll(
+                () -> assertThat(response.accessToken()).isEqualTo(ACCESS_TOKEN),
+                () -> assertThat(response.refreshToken()).isEqualTo(REFRESH_TOKEN)
+            );
+        }
+
+        @DisplayName("존재하지 않는 provider 를 요청할 경우 예외가 발생한다")
+        @Test
+        void notExistProvider() {
+            final String provider = "notExistProvider";
+            final OAuthRequest request = new OAuthRequest(provider, REDIRECT_URL, REFERRER_URL);
+            final OAuthCodeRequest codeRequest = new OAuthCodeRequest("authorizationCode");
+
+            assertThatThrownBy(() -> authService.login(request, codeRequest))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("잘못된 provider 입니다.");
+        }
+
+        @DisplayName("처음 로그인한 사용자는 사용자 정보를 저장 후 로그인한다")
+        @ParameterizedTest
+        @ValueSource(strings = {"google", "kakao"})
+        void register(final String provider) {
+            final OAuthRequest request = new OAuthRequest(provider, REDIRECT_URL, REFERRER_URL);
+            final OAuthCodeRequest codeRequest = new OAuthCodeRequest("authorizationCode");
+
+            given(memberRepository.findByOauthId(any())).willReturn(Optional.empty());
+            given(tokenGenerator.create(any(), eq(provider), any())).willReturn(new ServiceTokenResponse(ACCESS_TOKEN, REFRESH_TOKEN));
+
+            final OAuthTokenResponse response = authService.login(request, codeRequest);
+
+            assertAll(
+                () -> assertThat(response.accessToken()).isEqualTo(ACCESS_TOKEN),
+                () -> assertThat(response.refreshToken()).isEqualTo(REFRESH_TOKEN)
+            );
+        }
+    }
+
+    @DisplayName("Access Token 재발급 테스트")
+    @Nested
+    public class reissue {
+
+        @DisplayName("Access Token 을 재발급한다")
+        @ParameterizedTest
+        @ValueSource(strings = {"google", "kakao"})
+        void success(final String provider) {
+            final long memberId = 0L;
+            final String refreshToken = "refreshToken";
+            final String serviceToken = createToken(memberId, provider, refreshToken);
+
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(memberId, provider, refreshToken));
+            given(tokenRepository.exist(memberId)).willReturn(true);
+            given(tokenRepository.existRefreshToken(memberId, refreshToken)).willReturn(true);
+
+            assertThatCode(() -> authService.reissue(serviceToken))
+                .doesNotThrowAnyException();
+        }
+
+        @DisplayName("존재하지 않는 provider 를 요청할 경우 예외가 발생한다")
+        @Test
+        void notExistProvider() {
+            final long memberId = 0L;
+            final String provider = "notExistProvider";
+            final String refreshToken = "refreshToken";
+            final String serviceToken = createToken(memberId, provider, refreshToken);
+
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(memberId, provider, refreshToken));
+
+            assertThatThrownBy(() -> authService.reissue(serviceToken))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("잘못된 provider 입니다.");
+        }
 
         @DisplayName("memberId 가 존재하지 않을 경우 예외가 발생한다")
-        @Test
-        void notExistMemberId() {
+        @ParameterizedTest
+        @ValueSource(strings = {"google", "kakao"})
+        void notExistMemberId(final String provider) {
             final long notExistMemberId = 0L;
             final String existRefreshToken = "refreshToken";
-            final String serviceToken = createToken(notExistMemberId, PROVIDER, existRefreshToken);
+            final String serviceToken = createToken(notExistMemberId, provider, existRefreshToken);
 
-            given(tokenGenerator.extract(serviceToken))
-                .willReturn(new UserTokenResponse(notExistMemberId, PROVIDER, existRefreshToken));
-            given(tokenRepository.exist(notExistMemberId))
-                .willReturn(false);
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(notExistMemberId, provider, existRefreshToken));
+            given(tokenRepository.exist(notExistMemberId)).willReturn(false);
 
             assertThatThrownBy(() -> authService.reissue(serviceToken))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -108,18 +195,16 @@ class AuthServiceTest {
         }
 
         @DisplayName("refresh token 이 일치하지 않을 경우 예외가 발생한다")
-        @Test
-        void notEqualsRefreshToken() {
+        @ParameterizedTest
+        @ValueSource(strings = {"google", "kakao"})
+        void notEqualsRefreshToken(final String provider) {
             final long existMemberId = 0L;
             final String notExistRefreshToken = "refreshToken";
-            final String serviceToken = createToken(existMemberId, PROVIDER, notExistRefreshToken);
+            final String serviceToken = createToken(existMemberId, provider, notExistRefreshToken);
 
-            given(tokenGenerator.extract(serviceToken))
-                .willReturn(new UserTokenResponse(existMemberId, PROVIDER, notExistRefreshToken));
-            given(tokenRepository.exist(existMemberId))
-                .willReturn(true);
-            given(tokenRepository.existRefreshToken(existMemberId, notExistRefreshToken))
-                .willReturn(false);
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(existMemberId, provider, notExistRefreshToken));
+            given(tokenRepository.exist(existMemberId)).willReturn(true);
+            given(tokenRepository.existRefreshToken(existMemberId, notExistRefreshToken)).willReturn(false);
 
             assertThatThrownBy(() -> authService.reissue(serviceToken))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -135,9 +220,24 @@ class AuthServiceTest {
         }
     }
 
-    @DisplayName("로그아웃 시 로그인 여부 검증 테스트")
+    @DisplayName("로그아웃 테스트")
     @Nested
-    public class validateLogged {
+    public class logout {
+
+        @DisplayName("로그아웃한다")
+        @Test
+        void success() {
+            final long memberId = 0L;
+            final String provider = "google";
+            final String refreshToken = "refreshToken";
+            final String serviceToken = createToken(memberId, provider, refreshToken);
+
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(memberId, provider, refreshToken));
+            given(tokenRepository.exist(memberId)).willReturn(true);
+
+            assertThatCode(() -> authService.logout(serviceToken))
+                .doesNotThrowAnyException();
+        }
 
         @DisplayName("memberId 가 존재하지 않을 경우 예외가 발생한다")
         @Test
@@ -147,10 +247,8 @@ class AuthServiceTest {
             final String refreshToken = "refreshToken";
             final String serviceToken = createToken(notExistMemberId, provider, refreshToken);
 
-            given(tokenGenerator.extract(serviceToken))
-                .willReturn(new UserTokenResponse(notExistMemberId, provider, refreshToken));
-            given(tokenRepository.exist(notExistMemberId))
-                .willReturn(false);
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(notExistMemberId, provider, refreshToken));
+            given(tokenRepository.exist(notExistMemberId)).willReturn(false);
 
             assertThatThrownBy(() -> authService.logout(serviceToken))
                 .isInstanceOf(IllegalArgumentException.class)

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/FakeConnector.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/FakeConnector.java
@@ -16,16 +16,24 @@ public class FakeConnector implements OAuthConnector {
 
     @Override
     public TokenResponse requestToken(final String authorizationCode, final String redirectUrl) {
-        return null;
+        return new TokenResponse(
+            "accessToken", 1_000,
+            "refreshToken", 10_000,
+            "Bearer"
+        );
     }
 
     @Override
     public UserResponse requestUserInfo(final String tokenType, final String accessToken) {
-        return null;
+        return new UserResponse(String.valueOf(123456789));
     }
 
     @Override
     public TokenResponse requestAccessToken(final String refreshToken) {
-        return null;
+        return new TokenResponse(
+            "accessToken", 1_000,
+            "refreshToken", 10_000,
+            "Bearer"
+        );
     }
 }

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/FakeProvider.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/FakeProvider.java
@@ -4,6 +4,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.util.MultiValueMap;
 
 import com.dobugs.yologaauthenticationapi.support.OAuthProvider;
@@ -53,16 +55,28 @@ public class FakeProvider implements OAuthProvider {
 
     @Override
     public HttpEntity<MultiValueMap<String, String>> createTokenEntity() {
-        return null;
+        return new HttpEntity<>(createTokenHeaders());
     }
 
     @Override
     public HttpEntity<MultiValueMap<String, String>> createUserEntity(final String tokenType, final String accessToken) {
-        return null;
+        return new HttpEntity<>(createUserHeaders(tokenType, accessToken));
     }
 
     @Override
     public HttpEntity<MultiValueMap<String, String>> createAccessTokenEntity() {
-        return null;
+        return new HttpEntity<>(createTokenHeaders());
+    }
+
+    private HttpHeaders createTokenHeaders() {
+        final HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        return headers;
+    }
+
+    private HttpHeaders createUserHeaders(final String tokenType, final String accessToken) {
+        final HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", String.join(" ", tokenType, accessToken));
+        return headers;
     }
 }


### PR DESCRIPTION
## *관련 작업 티켓

- https://dobugs.atlassian.net/browse/YOL-148

## *작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- 처음 로그인 한 사용자는 회원가입을 진행합니다. 회원가입 시 사용자의 기본 닉네임을 설정하는 과정을 추가하였습니다.
  - 기본 닉네임 : DOBUGS#{id}
- FakeProvider, FakeConnector 를 정의 후 관련 테스트들을 추가하였습니다.

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)
