### PR TITLE
feat: 프로필 수정, 초기화 기능 구현

### DIFF
--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -28,3 +28,9 @@ Request
 include::{snippets}/member/delete/http-request.adoc[]
 Response
 include::{snippets}/member/delete/http-response.adoc[]
+
+== 프로필 초기화
+Request
+include::{snippets}/profile/init/http-request.adoc[]
+Response
+include::{snippets}/profile/init/http-response.adoc[]

--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -29,6 +29,12 @@ include::{snippets}/member/delete/http-request.adoc[]
 Response
 include::{snippets}/member/delete/http-response.adoc[]
 
+== 프로필 수정
+Request
+include::{snippets}/profile/update/http-request.adoc[]
+Response
+include::{snippets}/profile/update/http-response.adoc[]
+
 == 프로필 초기화
 Request
 include::{snippets}/profile/init/http-request.adoc[]

--- a/src/main/java/com/dobugs/yologaauthenticationapi/controller/ProfileController.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/controller/ProfileController.java
@@ -1,0 +1,25 @@
+package com.dobugs.yologaauthenticationapi.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.dobugs.yologaauthenticationapi.service.ProfileService;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/members/profile")
+@RestController
+public class ProfileController {
+
+    private final ProfileService profileService;
+
+    @DeleteMapping
+    public ResponseEntity<Void> init(@RequestHeader("Authorization") final String accessToken) {
+        profileService.init(accessToken);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/dobugs/yologaauthenticationapi/controller/ProfileController.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/controller/ProfileController.java
@@ -1,10 +1,15 @@
 package com.dobugs.yologaauthenticationapi.controller;
 
+import java.net.URI;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.dobugs.yologaauthenticationapi.service.ProfileService;
 
@@ -16,6 +21,15 @@ import lombok.RequiredArgsConstructor;
 public class ProfileController {
 
     private final ProfileService profileService;
+
+    @PostMapping
+    public ResponseEntity<Void> update(
+        @RequestHeader("Authorization") final String accessToken,
+        @RequestParam("profile") final MultipartFile newProfile
+    ) {
+        final String profileUrl = profileService.update(accessToken, newProfile);
+        return ResponseEntity.created(URI.create(profileUrl)).build();
+    }
 
     @DeleteMapping
     public ResponseEntity<Void> init(@RequestHeader("Authorization") final String accessToken) {

--- a/src/main/java/com/dobugs/yologaauthenticationapi/domain/BaseEntity.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/domain/BaseEntity.java
@@ -28,7 +28,7 @@ public abstract class BaseEntity {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
-    public void delete() {
+    public void deleteEntity() {
         archived = false;
         archivedAt = LocalDateTime.now();
     }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/domain/Member.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/domain/Member.java
@@ -52,6 +52,10 @@ public class Member extends BaseEntity {
         this.phoneNumber = phoneNumber;
     }
 
+    public void delete() {
+        deleteEntity();
+    }
+
     private void validateNickname(final String nickname) {
         if (nickname.length() > NICKNAME_LENGTH) {
             throw new IllegalArgumentException(String.format("닉네임은 %d자 이하여야 합니다. [%s]", NICKNAME_LENGTH, nickname));

--- a/src/main/java/com/dobugs/yologaauthenticationapi/domain/Member.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/domain/Member.java
@@ -7,6 +7,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -34,8 +36,9 @@ public class Member extends BaseEntity {
     @Column(length = PHONE_NUMBER_LENGTH)
     private String phoneNumber;
 
-    @Column
-    private int resourceId;
+    @OneToOne
+    @JoinColumn(name = "resource_id")
+    private Resource resource;
 
     public Member(final String oauthId) {
         this.oauthId = oauthId;

--- a/src/main/java/com/dobugs/yologaauthenticationapi/domain/Member.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/domain/Member.java
@@ -59,6 +59,10 @@ public class Member extends BaseEntity {
         deleteEntity();
     }
 
+    public void updateProfile(final Resource resource) {
+        this.resource = resource;
+    }
+
     public void deleteProfile() {
         this.resource = null;
     }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/domain/Member.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/domain/Member.java
@@ -59,6 +59,10 @@ public class Member extends BaseEntity {
         deleteEntity();
     }
 
+    public void deleteProfile() {
+        this.resource = null;
+    }
+
     private void validateNickname(final String nickname) {
         if (nickname.length() > NICKNAME_LENGTH) {
             throw new IllegalArgumentException(String.format("닉네임은 %d자 이하여야 합니다. [%s]", NICKNAME_LENGTH, nickname));

--- a/src/main/java/com/dobugs/yologaauthenticationapi/domain/Resource.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/domain/Resource.java
@@ -16,6 +16,9 @@ import lombok.NoArgsConstructor;
 @Entity
 public class Resource extends BaseEntity {
 
+    private static final int RESOURCE_KEY_LENGTH = 255;
+    private static final int RESOURCE_URL_LENGTH = 500;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -27,8 +30,28 @@ public class Resource extends BaseEntity {
     @Enumerated(value = EnumType.STRING)
     private ResourceType resourceType;
 
-    @Column(nullable = false, length = 500)
+    @Column(nullable = false, length = RESOURCE_URL_LENGTH)
     private String resourceUrl;
+
+    public Resource(final String resourceKey, final ResourceType resourceType, final String resourceUrl) {
+        validateResourceKey(resourceKey);
+        validateResourceUrl(resourceUrl);
+        this.resourceKey = resourceKey;
+        this.resourceType = resourceType;
+        this.resourceUrl = resourceUrl;
+    }
+
+    private void validateResourceKey(final String resourceKey) {
+        if (resourceKey.length() > RESOURCE_KEY_LENGTH) {
+            throw new IllegalArgumentException(String.format("리소스의 key 의 길이가 %d자 이상입니다. [%s]", RESOURCE_KEY_LENGTH, resourceKey));
+        }
+    }
+
+    private void validateResourceUrl(final String resourceUrl) {
+        if (resourceUrl.length() > RESOURCE_URL_LENGTH) {
+            throw new IllegalArgumentException(String.format("리소스의 URL 의 길이가 %d자 이상입니다. [%s]", RESOURCE_URL_LENGTH, resourceUrl));
+        }
+    }
 
     public void delete() {
         deleteEntity();

--- a/src/main/java/com/dobugs/yologaauthenticationapi/domain/Resource.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/domain/Resource.java
@@ -29,4 +29,8 @@ public class Resource extends BaseEntity {
 
     @Column(nullable = false, length = 500)
     private String resourceUrl;
+
+    public void delete() {
+        deleteEntity();
+    }
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/domain/Resource.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/domain/Resource.java
@@ -1,0 +1,32 @@
+package com.dobugs.yologaauthenticationapi.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Resource extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String resourceKey;
+
+    @Column(nullable = false, length = 50)
+    @Enumerated(value = EnumType.STRING)
+    private ResourceType resourceType;
+
+    @Column(nullable = false, length = 500)
+    private String resourceUrl;
+}

--- a/src/main/java/com/dobugs/yologaauthenticationapi/domain/ResourceType.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/domain/ResourceType.java
@@ -1,0 +1,13 @@
+package com.dobugs.yologaauthenticationapi.domain;
+
+public enum ResourceType {
+
+    PROFILE("profile_image"),
+    ;
+
+    private final String name;
+
+    ResourceType(final String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/dobugs/yologaauthenticationapi/repository/ResourceRepository.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/repository/ResourceRepository.java
@@ -1,0 +1,8 @@
+package com.dobugs.yologaauthenticationapi.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.dobugs.yologaauthenticationapi.domain.Resource;
+
+public interface ResourceRepository extends JpaRepository<Resource, Long> {
+}

--- a/src/main/java/com/dobugs/yologaauthenticationapi/service/AuthService.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/service/AuthService.java
@@ -25,7 +25,7 @@ import com.dobugs.yologaauthenticationapi.support.dto.response.UserTokenResponse
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 @Service
 public class AuthService {
 
@@ -35,6 +35,7 @@ public class AuthService {
     private final TokenRepository tokenRepository;
     private final TokenGenerator tokenGenerator;
 
+    @Transactional(readOnly = true)
     public OAuthLinkResponse generateOAuthUrl(final OAuthRequest request) {
         final OAuthConnector oAuthConnector = selectConnector(request.provider());
         final String redirectUrl = decode(request.redirect_url());
@@ -44,7 +45,6 @@ public class AuthService {
         return new OAuthLinkResponse(oAuthUrl);
     }
 
-    @Transactional
     public OAuthTokenResponse login(final OAuthRequest request, final OAuthCodeRequest codeRequest) {
         final String provider = request.provider();
         final OAuthConnector oAuthConnector = selectConnector(provider);
@@ -60,7 +60,6 @@ public class AuthService {
         return new OAuthTokenResponse(serviceTokenResponse.accessToken(), serviceTokenResponse.refreshToken());
     }
 
-    @Transactional
     public OAuthTokenResponse reissue(final String serviceToken) {
         final UserTokenResponse userTokenResponse = tokenGenerator.extract(serviceToken);
         final OAuthConnector oAuthConnector = selectConnector(userTokenResponse.provider());
@@ -72,7 +71,6 @@ public class AuthService {
         return new OAuthTokenResponse(response.accessToken(), response.refreshToken());
     }
 
-    @Transactional
     public void logout(final String serviceToken) {
         final UserTokenResponse userTokenResponse = tokenGenerator.extract(serviceToken);
         final Long memberId = userTokenResponse.memberId();

--- a/src/main/java/com/dobugs/yologaauthenticationapi/service/MemberService.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/service/MemberService.java
@@ -13,13 +13,14 @@ import com.dobugs.yologaauthenticationapi.support.dto.response.UserTokenResponse
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 @Service
 public class MemberService {
 
     private final MemberRepository memberRepository;
     private final TokenGenerator tokenGenerator;
 
+    @Transactional(readOnly = true)
     public MemberResponse findById(final Long memberId) {
         final Member savedMember = findMemberById(memberId);
         return new MemberResponse(
@@ -31,13 +32,13 @@ public class MemberService {
         );
     }
 
+    @Transactional(readOnly = true)
     public MemberResponse findMe(final String serviceToken) {
         final UserTokenResponse userTokenResponse = tokenGenerator.extract(serviceToken);
         final Long memberId = userTokenResponse.memberId();
         return findById(memberId);
     }
 
-    @Transactional
     public void update(final String serviceToken, final MemberUpdateRequest request) {
         final UserTokenResponse userTokenResponse = tokenGenerator.extract(serviceToken);
         final Long memberId = userTokenResponse.memberId();
@@ -45,7 +46,6 @@ public class MemberService {
         savedMember.update(request.nickname(), request.phoneNumber());
     }
 
-    @Transactional
     public void delete(final String serviceToken) {
         final UserTokenResponse userTokenResponse = tokenGenerator.extract(serviceToken);
         final Long memberId = userTokenResponse.memberId();

--- a/src/main/java/com/dobugs/yologaauthenticationapi/service/MemberService.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/service/MemberService.java
@@ -28,7 +28,7 @@ public class MemberService {
             savedMember.getOauthId(),
             savedMember.getNickname(),
             savedMember.getPhoneNumber(),
-            String.valueOf(savedMember.getResourceId())
+            String.valueOf(savedMember.getResource())
         );
     }
 

--- a/src/main/java/com/dobugs/yologaauthenticationapi/service/ProfileService.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/service/ProfileService.java
@@ -1,0 +1,41 @@
+package com.dobugs.yologaauthenticationapi.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.dobugs.yologaauthenticationapi.domain.Member;
+import com.dobugs.yologaauthenticationapi.domain.Resource;
+import com.dobugs.yologaauthenticationapi.repository.MemberRepository;
+import com.dobugs.yologaauthenticationapi.repository.ResourceRepository;
+import com.dobugs.yologaauthenticationapi.support.TokenGenerator;
+import com.dobugs.yologaauthenticationapi.support.dto.response.UserTokenResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class ProfileService {
+
+    private final ResourceRepository resourceRepository;
+    private final MemberRepository memberRepository;
+    private final TokenGenerator tokenGenerator;
+
+    public void init(final String serviceToken) {
+        final UserTokenResponse userTokenResponse = tokenGenerator.extract(serviceToken);
+        final Long memberId = userTokenResponse.memberId();
+
+        final Member savedMember = findMemberById(memberId);
+        final Resource savedResource = savedMember.getResource();
+        if (savedResource == null) {
+            return;
+        }
+        savedMember.deleteProfile();
+        savedResource.delete();
+    }
+
+    private Member findMemberById(final Long memberId) {
+        return memberRepository.findByIdAndArchivedIsTrue(memberId)
+            .orElseThrow(() -> new IllegalArgumentException(String.format("존재하지 않는 사용자입니다. [%d]", memberId)));
+    }
+}

--- a/src/main/java/com/dobugs/yologaauthenticationapi/service/ProfileService.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/service/ProfileService.java
@@ -2,11 +2,12 @@ package com.dobugs.yologaauthenticationapi.service;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.dobugs.yologaauthenticationapi.domain.Member;
 import com.dobugs.yologaauthenticationapi.domain.Resource;
+import com.dobugs.yologaauthenticationapi.domain.ResourceType;
 import com.dobugs.yologaauthenticationapi.repository.MemberRepository;
-import com.dobugs.yologaauthenticationapi.repository.ResourceRepository;
 import com.dobugs.yologaauthenticationapi.support.TokenGenerator;
 import com.dobugs.yologaauthenticationapi.support.dto.response.UserTokenResponse;
 
@@ -17,9 +18,26 @@ import lombok.RequiredArgsConstructor;
 @Service
 public class ProfileService {
 
-    private final ResourceRepository resourceRepository;
+    private static final ResourceType PROFILE_TYPE = ResourceType.PROFILE;
+
     private final MemberRepository memberRepository;
     private final TokenGenerator tokenGenerator;
+
+    public String update(final String serviceToken, final MultipartFile newProfile) {
+        final UserTokenResponse userTokenResponse = tokenGenerator.extract(serviceToken);
+        final Long memberId = userTokenResponse.memberId();
+
+        final Member savedMember = findMemberById(memberId);
+        final Resource savedResource = savedMember.getResource();
+        if (savedResource != null) {
+            savedResource.delete();
+        }
+
+        final Resource resource = new Resource("resourceKey", PROFILE_TYPE, "resourceUrl");
+        savedMember.updateProfile(resource);
+
+        return null;
+    }
 
     public void init(final String serviceToken) {
         final UserTokenResponse userTokenResponse = tokenGenerator.extract(serviceToken);

--- a/src/test/java/com/dobugs/yologaauthenticationapi/controller/ProfileControllerTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/controller/ProfileControllerTest.java
@@ -1,0 +1,48 @@
+package com.dobugs.yologaauthenticationapi.controller;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs
+@WebMvcTest(ProfileController.class)
+@ExtendWith({RestDocumentationExtension.class, MockitoExtension.class})
+@DisplayName("profile 컨트롤러 테스트")
+class ProfileControllerTest {
+
+    private static final String BASIC_URL = "/api/v1/members/profile";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @DisplayName("프로필을 초기화한다")
+    @Test
+    void init() throws Exception {
+        final String accessToken = "accessToken";
+
+        mockMvc.perform(delete(BASIC_URL)
+                .header("Authorization", accessToken))
+            .andExpect(status().isOk())
+            .andDo(document(
+                "profile/init",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()))
+            )
+        ;
+    }
+}

--- a/src/test/java/com/dobugs/yologaauthenticationapi/controller/ProfileControllerTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/controller/ProfileControllerTest.java
@@ -1,7 +1,9 @@
 package com.dobugs.yologaauthenticationapi.controller;
 
+import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
@@ -15,8 +17,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.web.servlet.MockMvc;
+
+import com.dobugs.yologaauthenticationapi.service.ProfileService;
 
 @AutoConfigureMockMvc
 @AutoConfigureRestDocs
@@ -29,6 +36,33 @@ class ProfileControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @MockBean
+    private ProfileService profileService;
+
+    @DisplayName("프로필을 수정한다")
+    @Test
+    void update() throws Exception {
+        final String accessToken = "accessToken";
+        final MockMultipartFile newProfile = new MockMultipartFile(
+            "profile",
+            "최종_최종_최종_프로필.png",
+            MediaType.IMAGE_PNG_VALUE,
+            "new profile content".getBytes()
+        );
+
+        given(profileService.update(accessToken, newProfile)).willReturn("profileUrl");
+
+        mockMvc.perform(multipart(BASIC_URL).file(newProfile)
+                .header("Authorization", accessToken))
+            .andExpect(status().isCreated())
+            .andDo(document(
+                "profile/update",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()))
+            )
+        ;
+    }
 
     @DisplayName("프로필을 초기화한다")
     @Test

--- a/src/test/java/com/dobugs/yologaauthenticationapi/domain/MemberTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/domain/MemberTest.java
@@ -75,4 +75,19 @@ class MemberTest {
                 .hasMessageContaining("올바른 전화번호 형식이 아닙니다.");
         }
     }
+
+    @DisplayName("사용자 삭제 테스트")
+    @Nested
+    public class delete {
+
+        @DisplayName("사용자를 삭제한다")
+        @Test
+        void success() {
+            final Member member = new Member("oauthId");
+
+            member.delete();
+
+            assertThat(member.isArchived()).isFalse();
+        }
+    }
 }

--- a/src/test/java/com/dobugs/yologaauthenticationapi/domain/MemberTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/domain/MemberTest.java
@@ -90,4 +90,19 @@ class MemberTest {
             assertThat(member.isArchived()).isFalse();
         }
     }
+
+    @DisplayName("사용자 프로필 삭제 테스트")
+    @Nested
+    public class deleteProfile {
+
+        @DisplayName("사용자 프로필을 삭제한다")
+        @Test
+        void success() {
+            final Member member = new Member("oauthId");
+
+            member.deleteProfile();
+
+            assertThat(member.getResource()).isNull();
+        }
+    }
 }

--- a/src/test/java/com/dobugs/yologaauthenticationapi/domain/MemberTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/domain/MemberTest.java
@@ -91,6 +91,22 @@ class MemberTest {
         }
     }
 
+    @DisplayName("사용자 프로필 수정 테스트")
+    @Nested
+    public class updateProfile {
+
+        @DisplayName("사용자 프로필을 수정한다")
+        @Test
+        void success() {
+            final Member member = new Member("oauthId");
+            final Resource resource = new Resource("resourceKey", ResourceType.PROFILE, "resourceUrl");
+
+            member.updateProfile(resource);
+
+            assertThat(member.getResource()).isEqualTo(resource);
+        }
+    }
+
     @DisplayName("사용자 프로필 삭제 테스트")
     @Nested
     public class deleteProfile {

--- a/src/test/java/com/dobugs/yologaauthenticationapi/domain/ResourceTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/domain/ResourceTest.java
@@ -1,6 +1,8 @@
 package com.dobugs.yologaauthenticationapi.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -8,6 +10,40 @@ import org.junit.jupiter.api.Test;
 
 @DisplayName("Resource 도메인 테스트")
 class ResourceTest {
+
+    @DisplayName("리소스 객체 생성 테스트")
+    @Nested
+    public class create {
+
+        @DisplayName("리소스 객체를 생성한다")
+        @Test
+        void success() {
+            assertThatCode(() -> new Resource("resourceKey", ResourceType.PROFILE, "resourceUrl"))
+                .doesNotThrowAnyException();
+        }
+
+        @DisplayName("리소스 키의 길이가 범위를 벗어나면 예외가 발생한다")
+        @Test
+        void resourceKeyLengthIsOverStandard() {
+            final String resourceKey = "resourceKey".repeat(255);
+
+            assertThatThrownBy(() -> new Resource(resourceKey, ResourceType.PROFILE, "resourceUrl"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("리소스의 key 의 길이가")
+                .hasMessageContaining("자 이상입니다.");
+        }
+
+        @DisplayName("리소스 URL 의 길이가 범위를 벗어나면 예외가 발생한다")
+        @Test
+        void resourceUrlLengthIsOverStandard() {
+            final String resourceUrl = "resourceUrl".repeat(500);
+
+            assertThatThrownBy(() -> new Resource("resourceKey", ResourceType.PROFILE, resourceUrl))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("리소스의 URL 의 길이가")
+                .hasMessageContaining("자 이상입니다.");
+        }
+    }
 
     @DisplayName("리소스 삭제 테스트")
     @Nested

--- a/src/test/java/com/dobugs/yologaauthenticationapi/domain/ResourceTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/domain/ResourceTest.java
@@ -1,0 +1,26 @@
+package com.dobugs.yologaauthenticationapi.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Resource 도메인 테스트")
+class ResourceTest {
+
+    @DisplayName("리소스 삭제 테스트")
+    @Nested
+    public class delete {
+
+        @DisplayName("리소스를 삭제한다")
+        @Test
+        void success() {
+            final Resource resource = new Resource();
+
+            resource.delete();
+
+            assertThat(resource.isArchived()).isFalse();
+        }
+    }
+}

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/ProfileServiceTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/ProfileServiceTest.java
@@ -1,0 +1,88 @@
+package com.dobugs.yologaauthenticationapi.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.dobugs.yologaauthenticationapi.domain.Member;
+import com.dobugs.yologaauthenticationapi.domain.Provider;
+import com.dobugs.yologaauthenticationapi.repository.MemberRepository;
+import com.dobugs.yologaauthenticationapi.repository.ResourceRepository;
+import com.dobugs.yologaauthenticationapi.support.TokenGenerator;
+import com.dobugs.yologaauthenticationapi.support.dto.response.UserTokenResponse;
+
+import io.jsonwebtoken.Jwts;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Profile 서비스 테스트")
+class ProfileServiceTest {
+
+    private ProfileService profileService;
+
+    @Mock
+    private ResourceRepository resourceRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private TokenGenerator tokenGenerator;
+
+    @BeforeEach
+    void setUp() {
+        profileService = new ProfileService(resourceRepository, memberRepository, tokenGenerator);
+    }
+
+    @DisplayName("프로필 초기화 테스트")
+    @Nested
+    public class init {
+
+        private static final Long MEMBER_ID = 0L;
+        private static final String PROVIDER = Provider.GOOGLE.getName();
+        private static final String ACCESS_TOKEN = "accessToken";
+
+        @DisplayName("프로필을 초기화한다")
+        @Test
+        void success() {
+            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+
+            final Member member = new Member("oauthId");
+            given(memberRepository.findByIdAndArchivedIsTrue(MEMBER_ID)).willReturn(Optional.of(member));
+
+            profileService.init(serviceToken);
+
+            assertThat(member.getResource()).isNull();
+        }
+
+        @DisplayName("존재하지 않는 사용자의 프로필을 초기화하면 예외가 발생한다")
+        @Test
+        void memberIsNotExist() {
+            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+            given(memberRepository.findByIdAndArchivedIsTrue(MEMBER_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> profileService.init(serviceToken))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("존재하지 않는 사용자입니다.");
+        }
+
+        private String createToken(final Long memberId, final String provider, final String token) {
+            return Jwts.builder()
+                .claim("memberId", memberId)
+                .claim("provider", provider)
+                .claim("token", token)
+                .compact();
+        }
+    }
+}

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/ProfileServiceTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/ProfileServiceTest.java
@@ -3,6 +3,7 @@ package com.dobugs.yologaauthenticationapi.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 import java.util.Optional;
 
@@ -13,11 +14,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.dobugs.yologaauthenticationapi.domain.Member;
 import com.dobugs.yologaauthenticationapi.domain.Provider;
+import com.dobugs.yologaauthenticationapi.domain.Resource;
 import com.dobugs.yologaauthenticationapi.repository.MemberRepository;
-import com.dobugs.yologaauthenticationapi.repository.ResourceRepository;
 import com.dobugs.yologaauthenticationapi.support.TokenGenerator;
 import com.dobugs.yologaauthenticationapi.support.dto.response.UserTokenResponse;
 
@@ -27,10 +29,11 @@ import io.jsonwebtoken.Jwts;
 @DisplayName("Profile 서비스 테스트")
 class ProfileServiceTest {
 
-    private ProfileService profileService;
+    private static final Long MEMBER_ID = 0L;
+    private static final String PROVIDER = Provider.GOOGLE.getName();
+    private static final String ACCESS_TOKEN = "accessToken";
 
-    @Mock
-    private ResourceRepository resourceRepository;
+    private ProfileService profileService;
 
     @Mock
     private MemberRepository memberRepository;
@@ -40,16 +43,20 @@ class ProfileServiceTest {
 
     @BeforeEach
     void setUp() {
-        profileService = new ProfileService(resourceRepository, memberRepository, tokenGenerator);
+        profileService = new ProfileService(memberRepository, tokenGenerator);
+    }
+
+    private String createToken(final Long memberId, final String provider, final String token) {
+        return Jwts.builder()
+            .claim("memberId", memberId)
+            .claim("provider", provider)
+            .claim("token", token)
+            .compact();
     }
 
     @DisplayName("프로필 초기화 테스트")
     @Nested
     public class init {
-
-        private static final Long MEMBER_ID = 0L;
-        private static final String PROVIDER = Provider.GOOGLE.getName();
-        private static final String ACCESS_TOKEN = "accessToken";
 
         @DisplayName("프로필을 초기화한다")
         @Test
@@ -76,13 +83,41 @@ class ProfileServiceTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("존재하지 않는 사용자입니다.");
         }
+    }
 
-        private String createToken(final Long memberId, final String provider, final String token) {
-            return Jwts.builder()
-                .claim("memberId", memberId)
-                .claim("provider", provider)
-                .claim("token", token)
-                .compact();
+    @DisplayName("프로필 수정 테스트")
+    @Nested
+    public class update {
+
+        @DisplayName("프로필을 수정한다")
+        @Test
+        void success() {
+            final MultipartFile newProfile = mock(MultipartFile.class);
+            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+
+            final Member member = new Member("oauthId");
+            given(memberRepository.findByIdAndArchivedIsTrue(MEMBER_ID)).willReturn(Optional.of(member));
+
+            final Resource beforeResource = member.getResource();
+            profileService.update(serviceToken, newProfile);
+            final Resource afterResource = member.getResource();
+
+            assertThat(afterResource).isNotEqualTo(beforeResource);
+        }
+
+        @DisplayName("존재하지 않는 사용자의 프로필을 수정하면 예외가 발생한다")
+        @Test
+        void memberIsNotExist() {
+            final MultipartFile newProfile = mock(MultipartFile.class);
+
+            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+            given(memberRepository.findByIdAndArchivedIsTrue(MEMBER_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> profileService.update(serviceToken, newProfile))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("존재하지 않는 사용자입니다.");
         }
     }
 }


### PR DESCRIPTION
## *관련 작업 티켓

- https://dobugs.atlassian.net/browse/YOL-145
- https://dobugs.atlassian.net/browse/YOL-146

## *작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- 프로필 수정 및 초기화 요청 시 테이블의 정보만 변경되도록 구현하였습니다.
- 현재는 S3 서버에 이미지가 직접 업로드 되거나 제거되지는 않습니다.

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)
