### PR TITLE
feat: s3 리소스 업로드 및 제거 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // aws
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.0.0-RC1'
 }
 
 /* RestDocs Start */

--- a/src/main/java/com/dobugs/yologaauthenticationapi/controller/MemberController.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/controller/MemberController.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -37,7 +38,7 @@ public class MemberController {
     @PostMapping
     public ResponseEntity<Void> update(
         @RequestHeader("Authorization") final String accessToken,
-        final MemberUpdateRequest request
+        @RequestBody final MemberUpdateRequest request
     ) {
         memberService.update(accessToken, request);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/dobugs/yologaauthenticationapi/domain/BaseEntity.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/domain/BaseEntity.java
@@ -28,6 +28,10 @@ public abstract class BaseEntity {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
+    public void saveEntity() {
+        archived = true;
+    }
+
     public void deleteEntity() {
         archived = false;
         archivedAt = LocalDateTime.now();

--- a/src/main/java/com/dobugs/yologaauthenticationapi/domain/Member.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/domain/Member.java
@@ -49,6 +49,10 @@ public class Member extends BaseEntity {
         nickname = INITIAL_NICKNAME_PREFIX + id;
     }
 
+    public void rejoin() {
+        saveEntity();
+    }
+
     public void update(final String nickname, final String phoneNumber) {
         validateNickname(nickname);
         validatePhoneNumber(phoneNumber);

--- a/src/main/java/com/dobugs/yologaauthenticationapi/domain/Member.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/domain/Member.java
@@ -2,6 +2,7 @@ package com.dobugs.yologaauthenticationapi.domain;
 
 import java.util.regex.Pattern;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -36,7 +37,7 @@ public class Member extends BaseEntity {
     @Column(length = PHONE_NUMBER_LENGTH)
     private String phoneNumber;
 
-    @OneToOne
+    @OneToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "resource_id")
     private Resource resource;
 

--- a/src/main/java/com/dobugs/yologaauthenticationapi/exception/ControllerAdvice.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/exception/ControllerAdvice.java
@@ -6,6 +6,10 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.dobugs.yologaauthenticationapi.exception.dto.response.ExceptionResponse;
 
+import io.awspring.cloud.s3.S3Exception;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.exception.SdkClientException;
+
 @RestControllerAdvice
 public class ControllerAdvice {
 
@@ -19,5 +23,17 @@ public class ControllerAdvice {
     public ResponseEntity<ExceptionResponse> handleBadRequest(Exception e) {
         final ExceptionResponse response = ExceptionResponse.from(e.getMessage());
         return ResponseEntity.badRequest().body(response);
+    }
+
+    @ExceptionHandler({AwsServiceException.class, S3Exception.class})
+    public ResponseEntity<ExceptionResponse> handleSdkServiceException(AwsServiceException e) {
+        final ExceptionResponse response = ExceptionResponse.from(e.getMessage());
+        return ResponseEntity.internalServerError().body(response);
+    }
+
+    @ExceptionHandler(SdkClientException.class)
+    public ResponseEntity<ExceptionResponse> handleSdkClientException(SdkClientException e) {
+        final ExceptionResponse response = ExceptionResponse.from(e.getMessage());
+        return ResponseEntity.internalServerError().body(response);
     }
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/service/AuthService.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/service/AuthService.java
@@ -68,7 +68,8 @@ public class AuthService {
         validateTheExistenceOfRefreshToken(userTokenResponse.memberId(), refreshToken);
         final TokenResponse response = oAuthConnector.requestAccessToken(refreshToken);
         restoreRefreshToken(userTokenResponse.memberId(), response.refreshToken());
-        return new OAuthTokenResponse(response.accessToken(), response.refreshToken());
+        final ServiceTokenResponse serviceTokenResponse = tokenGenerator.create(userTokenResponse.memberId(), userTokenResponse.provider(), response);
+        return new OAuthTokenResponse(serviceTokenResponse.accessToken(), serviceTokenResponse.refreshToken());
     }
 
     public void logout(final String serviceToken) {

--- a/src/main/java/com/dobugs/yologaauthenticationapi/service/MemberService.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/service/MemberService.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.dobugs.yologaauthenticationapi.domain.Member;
+import com.dobugs.yologaauthenticationapi.domain.Resource;
 import com.dobugs.yologaauthenticationapi.repository.MemberRepository;
 import com.dobugs.yologaauthenticationapi.service.dto.request.MemberUpdateRequest;
 import com.dobugs.yologaauthenticationapi.service.dto.response.MemberResponse;
@@ -23,12 +24,13 @@ public class MemberService {
     @Transactional(readOnly = true)
     public MemberResponse findById(final Long memberId) {
         final Member savedMember = findMemberById(memberId);
+        final String resourceUrl = getResourceUrl(savedMember);
         return new MemberResponse(
             savedMember.getId(),
             savedMember.getOauthId(),
             savedMember.getNickname(),
             savedMember.getPhoneNumber(),
-            String.valueOf(savedMember.getResource())
+            resourceUrl
         );
     }
 
@@ -51,6 +53,14 @@ public class MemberService {
         final Long memberId = userTokenResponse.memberId();
         final Member savedMember = findMemberById(memberId);
         savedMember.delete();
+    }
+
+    private String getResourceUrl(final Member savedMember) {
+        final Resource savedResource = savedMember.getResource();
+        if (savedResource == null) {
+            return null;
+        }
+        return savedResource.getResourceUrl();
     }
 
     private Member findMemberById(final Long memberId) {

--- a/src/main/java/com/dobugs/yologaauthenticationapi/service/ProfileService.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/service/ProfileService.java
@@ -9,6 +9,7 @@ import com.dobugs.yologaauthenticationapi.domain.Resource;
 import com.dobugs.yologaauthenticationapi.domain.ResourceType;
 import com.dobugs.yologaauthenticationapi.repository.MemberRepository;
 import com.dobugs.yologaauthenticationapi.support.StorageConnector;
+import com.dobugs.yologaauthenticationapi.support.StorageGenerator;
 import com.dobugs.yologaauthenticationapi.support.TokenGenerator;
 import com.dobugs.yologaauthenticationapi.support.dto.response.ResourceResponse;
 import com.dobugs.yologaauthenticationapi.support.dto.response.UserTokenResponse;
@@ -25,6 +26,7 @@ public class ProfileService {
     private final MemberRepository memberRepository;
     private final TokenGenerator tokenGenerator;
     private final StorageConnector s3Connector;
+    private final StorageGenerator s3Generator;
 
     public String update(final String serviceToken, final MultipartFile newProfile) {
         final UserTokenResponse userTokenResponse = tokenGenerator.extract(serviceToken);
@@ -37,7 +39,7 @@ public class ProfileService {
             s3Connector.delete(savedResource.getResourceKey());
         }
 
-        final ResourceResponse response = s3Connector.save(newProfile, "/", "profile.png");
+        final ResourceResponse response = s3Connector.save(newProfile, s3Generator.createPath(), s3Generator.createResourceName(newProfile));
         final Resource resource = new Resource(response.resourceKey(), PROFILE_TYPE, response.resourceUrl());
         savedMember.updateProfile(resource);
         return response.resourceUrl();

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/StorageConnector.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/StorageConnector.java
@@ -8,5 +8,5 @@ public interface StorageConnector {
 
     ResourceResponse save(MultipartFile resource, String path, String resourceName);
 
-    void delete(String resourceUrl);
+    void delete(String resourceKey);
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/StorageConnector.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/StorageConnector.java
@@ -1,0 +1,12 @@
+package com.dobugs.yologaauthenticationapi.support;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import com.dobugs.yologaauthenticationapi.support.dto.response.ResourceResponse;
+
+public interface StorageConnector {
+
+    ResourceResponse save(MultipartFile resource, String path, String resourceName);
+
+    void delete(String resourceUrl);
+}

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/StorageGenerator.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/StorageGenerator.java
@@ -1,0 +1,10 @@
+package com.dobugs.yologaauthenticationapi.support;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface StorageGenerator {
+
+    String createPath();
+
+    String createResourceName(MultipartFile resource);
+}

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/StorageProvider.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/StorageProvider.java
@@ -1,0 +1,6 @@
+package com.dobugs.yologaauthenticationapi.support;
+
+public interface StorageProvider {
+
+    String bucket();
+}

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/TokenGenerator.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/TokenGenerator.java
@@ -38,14 +38,15 @@ public class TokenGenerator {
 
     public ServiceTokenResponse create(final Long memberId, final String provider, final TokenResponse tokenResponse) {
         final Date now = new Date();
-        final String accessToken = createToken(memberId, provider, tokenResponse.accessToken(), now, new Date(now.getTime() + tokenResponse.expiresIn()));
+        final String accessToken = createToken(memberId, provider, tokenResponse.accessToken(), now, new Date(now.getTime() + tokenResponse.expiresIn() * 1000L));
         final String refreshToken = createToken(memberId, provider, tokenResponse.refreshToken(), now, extractRefreshTokenExpiration(tokenResponse, now));
 
         return new ServiceTokenResponse(accessToken, refreshToken);
     }
 
     public UserTokenResponse extract(final String serviceToken) {
-        final Claims claims = extractClaims(serviceToken);
+        final String jwt = serviceToken.replace("Bearer ", "");
+        final Claims claims = extractClaims(jwt);
         final Long memberId = extractMemberId(claims);
         final String token = extractToken(claims);
         final String provider = extractProvider(claims);
@@ -53,7 +54,7 @@ public class TokenGenerator {
     }
 
     private Date extractRefreshTokenExpiration(final TokenResponse tokenResponse, final Date now) {
-        final int expiresIn = tokenResponse.refreshTokenExpiresIn();
+        final long expiresIn = tokenResponse.refreshTokenExpiresIn() * 1000L;
         if (expiresIn < 0) {
             return new Date(now.getTime() + defaultRefreshTokenExpiresIn);
         }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/response/ResourceResponse.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/response/ResourceResponse.java
@@ -1,0 +1,4 @@
+package com.dobugs.yologaauthenticationapi.support.dto.response;
+
+public record ResourceResponse(String resourceKey, String resourceUrl) {
+}

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/resource/S3Connector.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/resource/S3Connector.java
@@ -1,7 +1,10 @@
 package com.dobugs.yologaauthenticationapi.support.resource;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
 
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
@@ -18,26 +21,45 @@ import lombok.RequiredArgsConstructor;
 @Component
 public class S3Connector implements StorageConnector {
 
+    private static final String DIRECTORY_REGEX = "/";
+
     private final S3Template s3Template;
     private final StorageProvider s3Provider;
 
     @Override
     public ResourceResponse save(final MultipartFile resource, final String path, final String resourceName) {
         final String resourceKey = concatResourceKey(path, resourceName);
-        final S3Resource savedResource = s3Template.store(s3Provider.bucket(), resourceKey, resource);
+        final ByteArrayInputStream serializedResource = serialize(resource);
+        final S3Resource savedResource = s3Template.store(s3Provider.bucket(), resourceKey, serializedResource);
         return createResourceResponse(resourceKey, savedResource);
     }
 
     @Override
-    public void delete(final String resourceUrl) {
-        s3Template.deleteObject(resourceUrl);
+    public void delete(final String resourceKey) {
+        s3Template.deleteObject(s3Provider.bucket(), resourceKey);
     }
 
     private String concatResourceKey(final String path, final String resourceName) {
-        if (path.endsWith("/")) {
-            return path + resourceName;
+        final String splitPath = split(path);
+        if (splitPath.equals("")) {
+            return resourceName;
         }
-        return String.join("/", path, resourceName);
+        return String.join(DIRECTORY_REGEX, splitPath, resourceName);
+    }
+
+    private String split(final String path) {
+        final List<String> splitPaths = Arrays.stream(path.split(DIRECTORY_REGEX))
+            .filter(split -> !split.equals(""))
+            .toList();
+        return String.join(DIRECTORY_REGEX, splitPaths);
+    }
+
+    private ByteArrayInputStream serialize(final MultipartFile resource) {
+        try {
+            return new ByteArrayInputStream(resource.getBytes());
+        } catch (IOException e) {
+            throw new IllegalArgumentException(e.getMessage());
+        }
     }
 
     private ResourceResponse createResourceResponse(final String resourceKey, final S3Resource resource) {

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/resource/S3Connector.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/resource/S3Connector.java
@@ -1,0 +1,51 @@
+package com.dobugs.yologaauthenticationapi.support.resource;
+
+import java.io.IOException;
+import java.net.URL;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.dobugs.yologaauthenticationapi.support.StorageConnector;
+import com.dobugs.yologaauthenticationapi.support.StorageProvider;
+import com.dobugs.yologaauthenticationapi.support.dto.response.ResourceResponse;
+
+import io.awspring.cloud.s3.S3Resource;
+import io.awspring.cloud.s3.S3Template;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Component
+public class S3Connector implements StorageConnector {
+
+    private final S3Template s3Template;
+    private final StorageProvider s3Provider;
+
+    @Override
+    public ResourceResponse save(final MultipartFile resource, final String path, final String resourceName) {
+        final String resourceKey = concatResourceKey(path, resourceName);
+        final S3Resource savedResource = s3Template.store(s3Provider.bucket(), resourceKey, resource);
+        return createResourceResponse(resourceKey, savedResource);
+    }
+
+    @Override
+    public void delete(final String resourceUrl) {
+        s3Template.deleteObject(resourceUrl);
+    }
+
+    private String concatResourceKey(final String path, final String resourceName) {
+        if (path.endsWith("/")) {
+            return path + resourceName;
+        }
+        return String.join("/", path, resourceName);
+    }
+
+    private ResourceResponse createResourceResponse(final String resourceKey, final S3Resource resource) {
+        try {
+            final URL resourceURL = resource.getURL();
+            return new ResourceResponse(resourceKey, resourceURL.toString());
+        } catch (IOException e) {
+            throw new IllegalArgumentException(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/resource/S3Generator.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/resource/S3Generator.java
@@ -2,10 +2,12 @@ package com.dobugs.yologaauthenticationapi.support.resource;
 
 import java.util.UUID;
 
+import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.dobugs.yologaauthenticationapi.support.StorageGenerator;
 
+@Component
 public class S3Generator implements StorageGenerator {
 
     private static final String DEFAULT_PROFILE_PATH = "/member/profile";

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/resource/S3Generator.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/resource/S3Generator.java
@@ -1,0 +1,25 @@
+package com.dobugs.yologaauthenticationapi.support.resource;
+
+import java.util.UUID;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import com.dobugs.yologaauthenticationapi.support.StorageGenerator;
+
+public class S3Generator implements StorageGenerator {
+
+    private static final String DEFAULT_PROFILE_PATH = "/member/profile";
+
+    @Override
+    public String createPath() {
+        return DEFAULT_PROFILE_PATH;
+    }
+
+    @Override
+    public String createResourceName(final MultipartFile resource) {
+        final String filename = resource.getOriginalFilename();
+        final String extension = filename.substring(filename.lastIndexOf(".") + 1);
+        final String resourceName = UUID.randomUUID().toString().replace("-", "");
+        return String.join(".", resourceName, extension);
+    }
+}

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/resource/S3Provider.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/resource/S3Provider.java
@@ -1,0 +1,23 @@
+package com.dobugs.yologaauthenticationapi.support.resource;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.dobugs.yologaauthenticationapi.support.StorageProvider;
+
+@Component
+public class S3Provider implements StorageProvider {
+    
+    private final String bucket;
+
+    public S3Provider(
+        @Value("${spring.cloud.aws.s3.bucket}") final String bucket
+    ) {
+        this.bucket = bucket;
+    }
+
+    @Override
+    public String bucket() {
+        return bucket;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,3 +5,4 @@ spring:
     import:
       - yologa-security/application-oauth2.yml
       - yologa-security/application-jwt.yml
+      - yologa-security/application-aws.yml

--- a/src/test/java/com/dobugs/yologaauthenticationapi/domain/MemberTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/domain/MemberTest.java
@@ -27,6 +27,22 @@ class MemberTest {
         }
     }
 
+    @DisplayName("사용자 재가입 테스트")
+    @Nested
+    public class rejoin {
+
+        @DisplayName("사용자 정보를 재가입시킨다")
+        @Test
+        void success() {
+            final Member member = new Member("oauthId");
+            member.delete();
+
+            member.rejoin();
+
+            assertThat(member.isArchived()).isTrue();
+        }
+    }
+
     @DisplayName("사용자 수정 테스트")
     @Nested
     public class update {

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/AuthServiceTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/AuthServiceTest.java
@@ -157,6 +157,7 @@ class AuthServiceTest {
             given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(memberId, provider, refreshToken));
             given(tokenRepository.exist(memberId)).willReturn(true);
             given(tokenRepository.existRefreshToken(memberId, refreshToken)).willReturn(true);
+            given(tokenGenerator.create(eq(memberId), eq(provider), any())).willReturn(new ServiceTokenResponse("accessToken", "refreshToken"));
 
             assertThatCode(() -> authService.reissue(serviceToken))
                 .doesNotThrowAnyException();

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/AuthServiceTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/AuthServiceTest.java
@@ -27,6 +27,7 @@ import com.dobugs.yologaauthenticationapi.service.dto.request.OAuthCodeRequest;
 import com.dobugs.yologaauthenticationapi.service.dto.request.OAuthRequest;
 import com.dobugs.yologaauthenticationapi.service.dto.response.OAuthLinkResponse;
 import com.dobugs.yologaauthenticationapi.service.dto.response.OAuthTokenResponse;
+import com.dobugs.yologaauthenticationapi.support.FakeOAuthConnector;
 import com.dobugs.yologaauthenticationapi.support.OAuthConnector;
 import com.dobugs.yologaauthenticationapi.support.TokenGenerator;
 import com.dobugs.yologaauthenticationapi.support.dto.response.ServiceTokenResponse;
@@ -52,11 +53,9 @@ class AuthServiceTest {
     @Mock
     private TokenGenerator tokenGenerator;
 
-    private OAuthConnector connector;
-
     @BeforeEach
     void setUp() {
-        connector = new FakeConnector();
+        final OAuthConnector connector = new FakeOAuthConnector();
         authService = new AuthService(connector, connector, memberRepository, tokenRepository, tokenGenerator);
     }
 

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/ProfileServiceTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/ProfileServiceTest.java
@@ -69,11 +69,16 @@ class ProfileServiceTest {
 
         private static final String RESOURCE_NAME = "profile.png";
 
+        final MockMultipartFile newProfile = new MockMultipartFile(
+            "profile",
+            "최종_최종_최종_프로필.png",
+            MediaType.IMAGE_PNG_VALUE,
+            "new profile content".getBytes()
+        );
+
         @DisplayName("프로필을 수정한다")
         @Test
         void success() {
-            final MultipartFile newProfile = mock(MultipartFile.class);
-
             final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
             given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
 
@@ -91,8 +96,6 @@ class ProfileServiceTest {
         @DisplayName("기존에 프로필이 없었더라도 프로필 수정에 성공한다")
         @Test
         void profileIsNull() {
-            final MultipartFile newProfile = mock(MultipartFile.class);
-
             final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
             given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
 
@@ -125,8 +128,6 @@ class ProfileServiceTest {
         @DisplayName("존재하지 않는 사용자의 프로필을 수정하면 예외가 발생한다")
         @Test
         void memberIsNotExist() {
-            final MultipartFile newProfile = mock(MultipartFile.class);
-
             final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
             given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
             given(memberRepository.findByIdAndArchivedIsTrue(MEMBER_ID)).willReturn(Optional.empty());

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/ProfileServiceTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/ProfileServiceTest.java
@@ -104,6 +104,24 @@ class ProfileServiceTest {
             assertThat(member.getResource()).isNotNull();
         }
 
+        @DisplayName("이미지 파일이 아닐 경우 예외가 발생한다")
+        @Test
+        void fileIsNotImage() {
+            final MockMultipartFile newProfile = new MockMultipartFile(
+                "profile",
+                "최종_최종_최종_프로필.png",
+                MediaType.APPLICATION_JSON_VALUE,
+                "new profile content".getBytes()
+            );
+
+            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+
+            assertThatThrownBy(() -> profileService.update(serviceToken, newProfile))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("프로필은 PNG, JPG 형식만 가능합니다.");
+        }
+
         @DisplayName("존재하지 않는 사용자의 프로필을 수정하면 예외가 발생한다")
         @Test
         void memberIsNotExist() {

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/ProfileServiceTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/ProfileServiceTest.java
@@ -24,6 +24,7 @@ import com.dobugs.yologaauthenticationapi.domain.Resource;
 import com.dobugs.yologaauthenticationapi.domain.ResourceType;
 import com.dobugs.yologaauthenticationapi.repository.MemberRepository;
 import com.dobugs.yologaauthenticationapi.support.FakeStorageConnector;
+import com.dobugs.yologaauthenticationapi.support.FakeStorageGenerator;
 import com.dobugs.yologaauthenticationapi.support.StorageConnector;
 import com.dobugs.yologaauthenticationapi.support.TokenGenerator;
 import com.dobugs.yologaauthenticationapi.support.dto.response.UserTokenResponse;
@@ -51,7 +52,7 @@ class ProfileServiceTest {
     @BeforeEach
     void setUp() {
         fakeS3Connector = new FakeStorageConnector();
-        profileService = new ProfileService(memberRepository, tokenGenerator, fakeS3Connector);
+        profileService = new ProfileService(memberRepository, tokenGenerator, fakeS3Connector, new FakeStorageGenerator());
     }
 
     private String createToken(final Long memberId, final String provider, final String token) {

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/ProfileServiceTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/ProfileServiceTest.java
@@ -14,12 +14,17 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.dobugs.yologaauthenticationapi.domain.Member;
 import com.dobugs.yologaauthenticationapi.domain.Provider;
 import com.dobugs.yologaauthenticationapi.domain.Resource;
+import com.dobugs.yologaauthenticationapi.domain.ResourceType;
 import com.dobugs.yologaauthenticationapi.repository.MemberRepository;
+import com.dobugs.yologaauthenticationapi.support.FakeStorageConnector;
+import com.dobugs.yologaauthenticationapi.support.StorageConnector;
 import com.dobugs.yologaauthenticationapi.support.TokenGenerator;
 import com.dobugs.yologaauthenticationapi.support.dto.response.UserTokenResponse;
 
@@ -41,9 +46,12 @@ class ProfileServiceTest {
     @Mock
     private TokenGenerator tokenGenerator;
 
+    private StorageConnector fakeS3Connector;
+
     @BeforeEach
     void setUp() {
-        profileService = new ProfileService(memberRepository, tokenGenerator);
+        fakeS3Connector = new FakeStorageConnector();
+        profileService = new ProfileService(memberRepository, tokenGenerator, fakeS3Connector);
     }
 
     private String createToken(final Long memberId, final String provider, final String token) {
@@ -54,13 +62,98 @@ class ProfileServiceTest {
             .compact();
     }
 
+    @DisplayName("프로필 수정 테스트")
+    @Nested
+    public class update {
+
+        private static final String RESOURCE_NAME = "profile.png";
+
+        @DisplayName("프로필을 수정한다")
+        @Test
+        void success() {
+            final MultipartFile newProfile = mock(MultipartFile.class);
+
+            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+
+            final Member member = new Member("oauthId");
+            member.updateProfile(new Resource(RESOURCE_NAME, ResourceType.PROFILE, "http://localhost:8080/profile.png"));
+            given(memberRepository.findByIdAndArchivedIsTrue(MEMBER_ID)).willReturn(Optional.of(member));
+
+            final Resource beforeResource = member.getResource();
+            profileService.update(serviceToken, newProfile);
+            final Resource afterResource = member.getResource();
+
+            assertThat(afterResource).isNotEqualTo(beforeResource);
+        }
+
+        @DisplayName("기존에 프로필이 없었더라도 프로필 수정에 성공한다")
+        @Test
+        void profileIsNull() {
+            final MultipartFile newProfile = mock(MultipartFile.class);
+
+            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+
+            final Member member = new Member("oauthId");
+            given(memberRepository.findByIdAndArchivedIsTrue(MEMBER_ID)).willReturn(Optional.of(member));
+
+            profileService.update(serviceToken, newProfile);
+
+            assertThat(member.getResource()).isNotNull();
+        }
+
+        @DisplayName("존재하지 않는 사용자의 프로필을 수정하면 예외가 발생한다")
+        @Test
+        void memberIsNotExist() {
+            final MultipartFile newProfile = mock(MultipartFile.class);
+
+            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+            given(memberRepository.findByIdAndArchivedIsTrue(MEMBER_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> profileService.update(serviceToken, newProfile))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("존재하지 않는 사용자입니다.");
+        }
+    }
+
     @DisplayName("프로필 초기화 테스트")
     @Nested
     public class init {
 
+        private static final String RESOURCE_NAME = "profile.png";
+
+        private final MockMultipartFile resource = new MockMultipartFile(
+            "profile",
+            "최종_최종_최종_프로필.png",
+            MediaType.IMAGE_PNG_VALUE,
+            "new profile content".getBytes()
+        );
+
+        @BeforeEach
+        void setUp() {
+            fakeS3Connector.save(resource, "/", RESOURCE_NAME);
+        }
+
         @DisplayName("프로필을 초기화한다")
         @Test
         void success() {
+            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+
+            final Member member = new Member("oauthId");
+            member.updateProfile(new Resource(RESOURCE_NAME, ResourceType.PROFILE, "http://localhost:8080/profile.png"));
+            given(memberRepository.findByIdAndArchivedIsTrue(MEMBER_ID)).willReturn(Optional.of(member));
+
+            profileService.init(serviceToken);
+
+            assertThat(member.getResource()).isNull();
+        }
+
+        @DisplayName("기존에 프로필이 없었더라도 프로필 초기화에 성공한다")
+        @Test
+        void profileIsNull() {
             final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
             given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
 
@@ -80,42 +173,6 @@ class ProfileServiceTest {
             given(memberRepository.findByIdAndArchivedIsTrue(MEMBER_ID)).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> profileService.init(serviceToken))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("존재하지 않는 사용자입니다.");
-        }
-    }
-
-    @DisplayName("프로필 수정 테스트")
-    @Nested
-    public class update {
-
-        @DisplayName("프로필을 수정한다")
-        @Test
-        void success() {
-            final MultipartFile newProfile = mock(MultipartFile.class);
-            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
-
-            final Member member = new Member("oauthId");
-            given(memberRepository.findByIdAndArchivedIsTrue(MEMBER_ID)).willReturn(Optional.of(member));
-
-            final Resource beforeResource = member.getResource();
-            profileService.update(serviceToken, newProfile);
-            final Resource afterResource = member.getResource();
-
-            assertThat(afterResource).isNotEqualTo(beforeResource);
-        }
-
-        @DisplayName("존재하지 않는 사용자의 프로필을 수정하면 예외가 발생한다")
-        @Test
-        void memberIsNotExist() {
-            final MultipartFile newProfile = mock(MultipartFile.class);
-
-            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
-            given(memberRepository.findByIdAndArchivedIsTrue(MEMBER_ID)).willReturn(Optional.empty());
-
-            assertThatThrownBy(() -> profileService.update(serviceToken, newProfile))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("존재하지 않는 사용자입니다.");
         }

--- a/src/test/java/com/dobugs/yologaauthenticationapi/support/FakeOAuthConnector.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/support/FakeOAuthConnector.java
@@ -1,13 +1,11 @@
-package com.dobugs.yologaauthenticationapi.service;
+package com.dobugs.yologaauthenticationapi.support;
 
-import com.dobugs.yologaauthenticationapi.support.OAuthConnector;
-import com.dobugs.yologaauthenticationapi.support.OAuthProvider;
 import com.dobugs.yologaauthenticationapi.support.dto.response.TokenResponse;
 import com.dobugs.yologaauthenticationapi.support.dto.response.UserResponse;
 
-public class FakeConnector implements OAuthConnector {
+public class FakeOAuthConnector implements OAuthConnector {
 
-    private final OAuthProvider provider = new FakeProvider();
+    private final OAuthProvider provider = new FakeOAuthProvider();
 
     @Override
     public String generateOAuthUrl(final String redirectUrl, final String referrer) {

--- a/src/test/java/com/dobugs/yologaauthenticationapi/support/FakeOAuthProvider.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/support/FakeOAuthProvider.java
@@ -1,4 +1,4 @@
-package com.dobugs.yologaauthenticationapi.service;
+package com.dobugs.yologaauthenticationapi.support;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -8,9 +8,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.util.MultiValueMap;
 
-import com.dobugs.yologaauthenticationapi.support.OAuthProvider;
-
-public class FakeProvider implements OAuthProvider {
+public class FakeOAuthProvider implements OAuthProvider {
 
     private static final String CLIENT_ID = "clientId";
     private static final String CLIENT_SECRET = "clientSecret";

--- a/src/test/java/com/dobugs/yologaauthenticationapi/support/FakeStorageConnector.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/support/FakeStorageConnector.java
@@ -1,0 +1,45 @@
+package com.dobugs.yologaauthenticationapi.support;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import com.dobugs.yologaauthenticationapi.support.dto.response.ResourceResponse;
+
+public class FakeStorageConnector implements StorageConnector {
+
+    private static final String DIRECTORY_REGEX = "/";
+
+    private final Map<String, MultipartFile> storage = new HashMap<>();
+
+    @Override
+    public ResourceResponse save(final MultipartFile resource, final String path, final String resourceName) {
+        final String resourceKey = concatResourceKey(path, resourceName);
+        final String resourceUrl = "http://localhost:8080/" + resourceKey;
+        storage.put(resourceKey, resource);
+        return new ResourceResponse(resourceKey, resourceUrl);
+    }
+
+    @Override
+    public void delete(final String resourceKey) {
+        storage.remove(resourceKey);
+    }
+
+    private String concatResourceKey(final String path, final String resourceName) {
+        final String splitPath = split(path);
+        if (splitPath.equals("")) {
+            return resourceName;
+        }
+        return String.join(DIRECTORY_REGEX, splitPath, resourceName);
+    }
+
+    private String split(final String path) {
+        final List<String> splitPaths = Arrays.stream(path.split(DIRECTORY_REGEX))
+            .filter(split -> !split.equals(""))
+            .toList();
+        return String.join(DIRECTORY_REGEX, splitPaths);
+    }
+}

--- a/src/test/java/com/dobugs/yologaauthenticationapi/support/FakeStorageGenerator.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/support/FakeStorageGenerator.java
@@ -1,0 +1,16 @@
+package com.dobugs.yologaauthenticationapi.support;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public class FakeStorageGenerator implements StorageGenerator {
+
+    @Override
+    public String createPath() {
+        return "/path";
+    }
+
+    @Override
+    public String createResourceName(final MultipartFile resource) {
+        return "profile.png";
+    }
+}

--- a/src/test/java/com/dobugs/yologaauthenticationapi/support/FakeStorageProvider.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/support/FakeStorageProvider.java
@@ -1,0 +1,11 @@
+package com.dobugs.yologaauthenticationapi.support;
+
+public class FakeStorageProvider implements StorageProvider {
+
+    private final String BUCKET_NAME = "bucket";
+
+    @Override
+    public String bucket() {
+        return BUCKET_NAME;
+    }
+}

--- a/src/test/java/com/dobugs/yologaauthenticationapi/support/resource/S3ConnectorTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/support/resource/S3ConnectorTest.java
@@ -1,0 +1,93 @@
+package com.dobugs.yologaauthenticationapi.support.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+import java.net.URL;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+
+import com.dobugs.yologaauthenticationapi.support.FakeStorageProvider;
+import com.dobugs.yologaauthenticationapi.support.StorageConnector;
+import com.dobugs.yologaauthenticationapi.support.StorageProvider;
+import com.dobugs.yologaauthenticationapi.support.dto.response.ResourceResponse;
+
+import io.awspring.cloud.s3.S3Resource;
+import io.awspring.cloud.s3.S3Template;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("S3Connector 테스트")
+class S3ConnectorTest {
+
+    private static final String PROTOCOL = "http";
+    private static final String HOST = "localhost";
+    private static final int PORT = 8080;
+
+    private StorageConnector s3Connector;
+
+    private StorageProvider fakeStorageProvider;
+
+    @Mock
+    private S3Template s3Template;
+
+    @BeforeEach
+    void setUp() {
+        fakeStorageProvider = new FakeStorageProvider();
+        s3Connector = new S3Connector(s3Template, fakeStorageProvider);
+    }
+
+    @DisplayName("리소스 저장 테스트")
+    @Nested
+    public class save {
+
+        private static final String PATH = "/";
+        private static final String RESOURCE_NAME = "profile.png";
+        private static final String RESOURCE_KEY = PATH + RESOURCE_NAME;
+
+        private final MockMultipartFile resource = new MockMultipartFile(
+            "profile",
+            "최종_최종_최종_프로필.png",
+            MediaType.IMAGE_PNG_VALUE,
+            "new profile content".getBytes()
+        );
+
+        @DisplayName("리소스를 저장한다")
+        @Test
+        void success() throws IOException {
+            final S3Resource s3Resource = mock(S3Resource.class);
+            given(s3Resource.getURL()).willReturn(new URL(PROTOCOL, HOST, PORT, RESOURCE_KEY));
+            given(s3Template.store(fakeStorageProvider.bucket(), RESOURCE_KEY, resource)).willReturn(s3Resource);
+
+            final ResourceResponse response = s3Connector.save(resource, PATH, RESOURCE_NAME);
+
+            assertAll(
+                () -> assertThat(response.resourceKey()).isEqualTo(RESOURCE_KEY),
+                () -> assertThat(response.resourceUrl()).isEqualTo(PROTOCOL + "://" + HOST + ":" + PORT + RESOURCE_KEY)
+            );
+        }
+    }
+
+    @DisplayName("리소스 삭제 테스트")
+    @Nested
+    public class delete {
+
+        @DisplayName("리소스를 삭제한다")
+        @Test
+        void success() {
+            assertThatCode(() -> s3Connector.delete("resourceUrl"))
+                .doesNotThrowAnyException();
+        }
+    }
+}

--- a/src/test/java/com/dobugs/yologaauthenticationapi/support/resource/S3GeneratorTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/support/resource/S3GeneratorTest.java
@@ -1,0 +1,38 @@
+package com.dobugs.yologaauthenticationapi.support.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+
+import com.dobugs.yologaauthenticationapi.support.StorageGenerator;
+
+@DisplayName("S3Generator 테스트")
+class S3GeneratorTest {
+
+    private StorageGenerator s3Generator;
+
+    @BeforeEach
+    void setUp() {
+        s3Generator = new S3Generator();
+    }
+
+    @DisplayName("리소스의 이름을 생성한다")
+    @Test
+    void createResourceName() {
+        final String extension = "png";
+        final MockMultipartFile resource = new MockMultipartFile(
+            "profile",
+            "최종_최종_최종_프로필." + extension,
+            MediaType.IMAGE_PNG_VALUE,
+            "new profile content".getBytes()
+        );
+
+        final String resourceName = s3Generator.createResourceName(resource);
+
+        assertThat(resourceName).endsWith("." + extension);
+    }
+}


### PR DESCRIPTION
## *관련 작업 티켓

- https://dobugs.atlassian.net/browse/YOL-149

## *작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- S3 에 접근하여 리소스를 업로드하거나 제거하는 기능을 구현하였습니다.
- 리소스 관련 기능 외에 문제가 발생하는 부분들을 수정하였습니다.
  - JWT 토큰 발급 과정 에러 해결
  - Member, Resource Cascade 설정 추가
  - 탈퇴한 사용자 재가입 기능 구현
  - Resource 가 있는 사용자일 경우 사용자 정보 조회 시 URL 응답

## 관련 Docs

- [AWS S3 에서 Resource 관리하기](https://cactus-treatment-26e.notion.site/AWS-S3-Resource-35aadceb45874333b8ddd2a0c761f5de)

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)
