### PR TITLE
fix: 구글 OAuth2.0 로그인 시 redis 에 저장안되는 문제

### DIFF
--- a/src/main/java/com/dobugs/yologaauthenticationapi/controller/AuthController.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/controller/AuthController.java
@@ -13,7 +13,7 @@ import com.dobugs.yologaauthenticationapi.service.AuthService;
 import com.dobugs.yologaauthenticationapi.service.dto.request.OAuthCodeRequest;
 import com.dobugs.yologaauthenticationapi.service.dto.request.OAuthRequest;
 import com.dobugs.yologaauthenticationapi.service.dto.response.OAuthLinkResponse;
-import com.dobugs.yologaauthenticationapi.service.dto.response.OAuthTokenResponse;
+import com.dobugs.yologaauthenticationapi.service.dto.response.ServiceTokenResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -31,17 +31,17 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<OAuthTokenResponse> login(
+    public ResponseEntity<ServiceTokenResponse> login(
         @ModelAttribute final OAuthRequest request,
         @RequestBody final OAuthCodeRequest codeRequest
     ) {
-        final OAuthTokenResponse response = authService.login(request, codeRequest);
+        final ServiceTokenResponse response = authService.login(request, codeRequest);
         return ResponseEntity.ok(response);
     }
 
     @PostMapping("/reissue")
-    public ResponseEntity<OAuthTokenResponse> reissue(@RequestHeader("Authorization") final String refreshToken) {
-        final OAuthTokenResponse response = authService.reissue(refreshToken);
+    public ResponseEntity<ServiceTokenResponse> reissue(@RequestHeader("Authorization") final String refreshToken) {
+        final ServiceTokenResponse response = authService.reissue(refreshToken);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/dobugs/yologaauthenticationapi/service/AuthService.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/service/AuthService.java
@@ -14,12 +14,12 @@ import com.dobugs.yologaauthenticationapi.repository.TokenRepository;
 import com.dobugs.yologaauthenticationapi.service.dto.request.OAuthCodeRequest;
 import com.dobugs.yologaauthenticationapi.service.dto.request.OAuthRequest;
 import com.dobugs.yologaauthenticationapi.service.dto.response.OAuthLinkResponse;
-import com.dobugs.yologaauthenticationapi.service.dto.response.OAuthTokenResponse;
+import com.dobugs.yologaauthenticationapi.service.dto.response.ServiceTokenResponse;
 import com.dobugs.yologaauthenticationapi.support.OAuthConnector;
 import com.dobugs.yologaauthenticationapi.support.TokenGenerator;
-import com.dobugs.yologaauthenticationapi.support.dto.response.ServiceTokenResponse;
-import com.dobugs.yologaauthenticationapi.support.dto.response.TokenResponse;
-import com.dobugs.yologaauthenticationapi.support.dto.response.UserResponse;
+import com.dobugs.yologaauthenticationapi.support.dto.response.ServiceTokenDto;
+import com.dobugs.yologaauthenticationapi.support.dto.response.OAuthTokenResponse;
+import com.dobugs.yologaauthenticationapi.support.dto.response.OAuthUserResponse;
 import com.dobugs.yologaauthenticationapi.support.dto.response.UserTokenResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -45,31 +45,31 @@ public class AuthService {
         return new OAuthLinkResponse(oAuthUrl);
     }
 
-    public OAuthTokenResponse login(final OAuthRequest request, final OAuthCodeRequest codeRequest) {
+    public ServiceTokenResponse login(final OAuthRequest request, final OAuthCodeRequest codeRequest) {
         final String provider = request.provider();
         final OAuthConnector oAuthConnector = selectConnector(provider);
         final String redirectUrl = decode(request.redirect_url());
         final String authorizationCode = decode(codeRequest.authorizationCode());
 
-        final TokenResponse tokenResponse = oAuthConnector.requestToken(authorizationCode, redirectUrl);
-        final UserResponse userResponse = oAuthConnector.requestUserInfo(tokenResponse.tokenType(), tokenResponse.accessToken());
+        final OAuthTokenResponse oAuthTokenResponse = oAuthConnector.requestToken(authorizationCode, redirectUrl);
+        final OAuthUserResponse oAuthUserResponse = oAuthConnector.requestUserInfo(oAuthTokenResponse.tokenType(), oAuthTokenResponse.accessToken());
 
-        final Long memberId = saveMember(provider, tokenResponse, userResponse);
-        final ServiceTokenResponse serviceTokenResponse = tokenGenerator.create(memberId, provider, tokenResponse);
+        final Long memberId = saveMember(provider, oAuthTokenResponse, oAuthUserResponse);
+        final ServiceTokenDto serviceTokenDto = tokenGenerator.create(memberId, provider, oAuthTokenResponse);
 
-        return new OAuthTokenResponse(serviceTokenResponse.accessToken(), serviceTokenResponse.refreshToken());
+        return new ServiceTokenResponse(serviceTokenDto.accessToken(), serviceTokenDto.refreshToken());
     }
 
-    public OAuthTokenResponse reissue(final String serviceToken) {
+    public ServiceTokenResponse reissue(final String serviceToken) {
         final UserTokenResponse userTokenResponse = tokenGenerator.extract(serviceToken);
         final OAuthConnector oAuthConnector = selectConnector(userTokenResponse.provider());
         final String refreshToken = decode(userTokenResponse.token());
 
         validateTheExistenceOfRefreshToken(userTokenResponse.memberId(), refreshToken);
-        final TokenResponse response = oAuthConnector.requestAccessToken(refreshToken);
+        final OAuthTokenResponse response = oAuthConnector.requestAccessToken(refreshToken);
         restoreRefreshToken(userTokenResponse.memberId(), response.refreshToken());
-        final ServiceTokenResponse serviceTokenResponse = tokenGenerator.create(userTokenResponse.memberId(), userTokenResponse.provider(), response);
-        return new OAuthTokenResponse(serviceTokenResponse.accessToken(), serviceTokenResponse.refreshToken());
+        final ServiceTokenDto serviceTokenDto = tokenGenerator.create(userTokenResponse.memberId(), userTokenResponse.provider(), response);
+        return new ServiceTokenResponse(serviceTokenDto.accessToken(), serviceTokenDto.refreshToken());
     }
 
     public void logout(final String serviceToken) {
@@ -80,16 +80,16 @@ public class AuthService {
         tokenRepository.delete(memberId);
     }
 
-    private Long saveMember(final String provider, final TokenResponse tokenResponse, final UserResponse userResponse) {
-        final Member savedMember = saveMemberToMySQL(userResponse);
-        saveMemberToRedis(provider, tokenResponse, savedMember);
+    private Long saveMember(final String provider, final OAuthTokenResponse oAuthTokenResponse, final OAuthUserResponse OAuthUserResponse) {
+        final Member savedMember = saveMemberToMySQL(OAuthUserResponse);
+        saveMemberToRedis(provider, oAuthTokenResponse, savedMember);
         return savedMember.getId();
     }
 
-    private Member saveMemberToMySQL(final UserResponse userResponse) {
-        final Member savedMember = memberRepository.findByOauthId(userResponse.oAuthId())
+    private Member saveMemberToMySQL(final OAuthUserResponse OAuthUserResponse) {
+        final Member savedMember = memberRepository.findByOauthId(OAuthUserResponse.oAuthId())
             .orElseGet(() -> {
-                final Member member = new Member(userResponse.oAuthId());
+                final Member member = new Member(OAuthUserResponse.oAuthId());
                 memberRepository.save(member);
                 member.init();
                 return member;
@@ -100,10 +100,10 @@ public class AuthService {
         return savedMember;
     }
 
-    private void saveMemberToRedis(final String provider, final TokenResponse tokenResponse, final Member savedMember) {
+    private void saveMemberToRedis(final String provider, final OAuthTokenResponse oAuthTokenResponse, final Member savedMember) {
         final OAuthToken oAuthToken = OAuthToken.login(
             savedMember.getId(), Provider.findOf(provider),
-            tokenResponse.refreshToken(), (long) tokenResponse.refreshTokenExpiresIn()
+            oAuthTokenResponse.refreshToken(), (long) oAuthTokenResponse.refreshTokenExpiresIn()
         );
         tokenRepository.save(oAuthToken);
     }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/service/dto/response/OAuthTokenResponse.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/service/dto/response/OAuthTokenResponse.java
@@ -1,4 +1,0 @@
-package com.dobugs.yologaauthenticationapi.service.dto.response;
-
-public record OAuthTokenResponse(String accessToken, String refreshToken) {
-}

--- a/src/main/java/com/dobugs/yologaauthenticationapi/service/dto/response/ServiceTokenResponse.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/service/dto/response/ServiceTokenResponse.java
@@ -1,4 +1,4 @@
-package com.dobugs.yologaauthenticationapi.support.dto.response;
+package com.dobugs.yologaauthenticationapi.service.dto.response;
 
 public record ServiceTokenResponse(String accessToken, String refreshToken) {
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/OAuthConnector.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/OAuthConnector.java
@@ -2,8 +2,8 @@ package com.dobugs.yologaauthenticationapi.support;
 
 import org.springframework.web.client.RestTemplate;
 
-import com.dobugs.yologaauthenticationapi.support.dto.response.TokenResponse;
-import com.dobugs.yologaauthenticationapi.support.dto.response.UserResponse;
+import com.dobugs.yologaauthenticationapi.support.dto.response.OAuthTokenResponse;
+import com.dobugs.yologaauthenticationapi.support.dto.response.OAuthUserResponse;
 
 public interface OAuthConnector {
 
@@ -11,9 +11,9 @@ public interface OAuthConnector {
 
     String generateOAuthUrl(String redirectUrl, String referrer);
 
-    TokenResponse requestToken(String authorizationCode, String redirectUrl);
+    OAuthTokenResponse requestToken(String authorizationCode, String redirectUrl);
 
-    UserResponse requestUserInfo(String tokenType, String accessToken);
+    OAuthUserResponse requestUserInfo(String tokenType, String accessToken);
 
-    TokenResponse requestAccessToken(String refreshToken);
+    OAuthTokenResponse requestAccessToken(String refreshToken);
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/TokenGenerator.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/TokenGenerator.java
@@ -8,12 +8,11 @@ import javax.crypto.SecretKey;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import com.dobugs.yologaauthenticationapi.support.dto.response.TokenResponse;
-import com.dobugs.yologaauthenticationapi.support.dto.response.ServiceTokenResponse;
+import com.dobugs.yologaauthenticationapi.support.dto.response.OAuthTokenResponse;
+import com.dobugs.yologaauthenticationapi.support.dto.response.ServiceTokenDto;
 import com.dobugs.yologaauthenticationapi.support.dto.response.UserTokenResponse;
 
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
@@ -36,12 +35,13 @@ public class TokenGenerator {
         this.defaultRefreshTokenExpiresIn = defaultRefreshTokenExpiresIn;
     }
 
-    public ServiceTokenResponse create(final Long memberId, final String provider, final TokenResponse tokenResponse) {
+    public ServiceTokenDto create(final Long memberId, final String provider, final OAuthTokenResponse oAuthTokenResponse) {
         final Date now = new Date();
-        final String accessToken = createToken(memberId, provider, tokenResponse.accessToken(), now, new Date(now.getTime() + tokenResponse.expiresIn() * 1000L));
-        final String refreshToken = createToken(memberId, provider, tokenResponse.refreshToken(), now, extractRefreshTokenExpiration(tokenResponse, now));
+        final String accessToken = createToken(memberId, provider, oAuthTokenResponse.accessToken(), now, new Date(now.getTime() + oAuthTokenResponse.expiresIn() * 1000L));
+        final String refreshToken = createToken(memberId, provider, oAuthTokenResponse.refreshToken(), now, extractRefreshTokenExpiration(
+            oAuthTokenResponse, now));
 
-        return new ServiceTokenResponse(accessToken, refreshToken);
+        return new ServiceTokenDto(accessToken, refreshToken);
     }
 
     public UserTokenResponse extract(final String serviceToken) {
@@ -53,8 +53,8 @@ public class TokenGenerator {
         return new UserTokenResponse(memberId, provider, token);
     }
 
-    private Date extractRefreshTokenExpiration(final TokenResponse tokenResponse, final Date now) {
-        final long expiresIn = tokenResponse.refreshTokenExpiresIn() * 1000L;
+    private Date extractRefreshTokenExpiration(final OAuthTokenResponse oAuthTokenResponse, final Date now) {
+        final long expiresIn = oAuthTokenResponse.refreshTokenExpiresIn() * 1000L;
         if (expiresIn < 0) {
             return new Date(now.getTime() + defaultRefreshTokenExpiresIn);
         }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/response/OAuthTokenDto.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/response/OAuthTokenDto.java
@@ -1,0 +1,4 @@
+package com.dobugs.yologaauthenticationapi.support.dto.response;
+
+public record OAuthTokenDto(String accessToken, int expiresIn, String refreshToken, int refreshTokenExpiresIn, String tokenType) {
+}

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/response/OAuthTokenResponse.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/response/OAuthTokenResponse.java
@@ -1,0 +1,4 @@
+package com.dobugs.yologaauthenticationapi.support.dto.response;
+
+public record OAuthTokenResponse(String accessToken, int expiresIn, String refreshToken, int refreshTokenExpiresIn, String tokenType) {
+}

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/response/OAuthUserResponse.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/response/OAuthUserResponse.java
@@ -1,4 +1,4 @@
 package com.dobugs.yologaauthenticationapi.support.dto.response;
 
-public record UserResponse(String oAuthId) {
+public record OAuthUserResponse(String oAuthId) {
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/response/ServiceTokenDto.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/response/ServiceTokenDto.java
@@ -1,0 +1,4 @@
+package com.dobugs.yologaauthenticationapi.support.dto.response;
+
+public record ServiceTokenDto(String accessToken, String refreshToken) {
+}

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/response/TokenResponse.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/response/TokenResponse.java
@@ -1,4 +1,0 @@
-package com.dobugs.yologaauthenticationapi.support.dto.response;
-
-public record TokenResponse(String accessToken, int expiresIn, String refreshToken, int refreshTokenExpiresIn, String tokenType) {
-}

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleConnector.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleConnector.java
@@ -11,8 +11,8 @@ import com.dobugs.yologaauthenticationapi.support.OAuthConnector;
 import com.dobugs.yologaauthenticationapi.support.OAuthProvider;
 import com.dobugs.yologaauthenticationapi.support.dto.response.GoogleTokenResponse;
 import com.dobugs.yologaauthenticationapi.support.dto.response.GoogleUserResponse;
-import com.dobugs.yologaauthenticationapi.support.dto.response.TokenResponse;
-import com.dobugs.yologaauthenticationapi.support.dto.response.UserResponse;
+import com.dobugs.yologaauthenticationapi.support.dto.response.OAuthTokenResponse;
+import com.dobugs.yologaauthenticationapi.support.dto.response.OAuthUserResponse;
 import com.dobugs.yologaauthenticationapi.support.exception.OAuthConnectionException;
 
 import lombok.Getter;
@@ -33,22 +33,22 @@ public class GoogleConnector implements OAuthConnector {
     }
 
     @Override
-    public TokenResponse requestToken(final String authorizationCode, final String redirectUrl) {
+    public OAuthTokenResponse requestToken(final String authorizationCode, final String redirectUrl) {
         final GoogleTokenResponse response = connectForToken(authorizationCode, redirectUrl);
-        return new TokenResponse(response.access_token(), response.expires_in(), response.refresh_token(),
+        return new OAuthTokenResponse(response.access_token(), response.expires_in(), response.refresh_token(),
             REFRESH_TOKEN_EXPIRES_IN, response.token_type());
     }
 
     @Override
-    public UserResponse requestUserInfo(final String tokenType, final String accessToken) {
+    public OAuthUserResponse requestUserInfo(final String tokenType, final String accessToken) {
         final GoogleUserResponse response = connectForUserInfo(tokenType, accessToken);
-        return new UserResponse(response.id());
+        return new OAuthUserResponse(response.id());
     }
 
     @Override
-    public TokenResponse requestAccessToken(final String refreshToken) {
+    public OAuthTokenResponse requestAccessToken(final String refreshToken) {
         final GoogleTokenResponse response = connectForAccessToken(refreshToken);
-        return new TokenResponse(response.access_token(), response.expires_in(), refreshToken,
+        return new OAuthTokenResponse(response.access_token(), response.expires_in(), refreshToken,
             REFRESH_TOKEN_EXPIRES_IN, response.token_type());
     }
 

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoConnector.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoConnector.java
@@ -11,8 +11,8 @@ import com.dobugs.yologaauthenticationapi.support.OAuthConnector;
 import com.dobugs.yologaauthenticationapi.support.OAuthProvider;
 import com.dobugs.yologaauthenticationapi.support.dto.response.KakaoTokenResponse;
 import com.dobugs.yologaauthenticationapi.support.dto.response.KakaoUserResponse;
-import com.dobugs.yologaauthenticationapi.support.dto.response.TokenResponse;
-import com.dobugs.yologaauthenticationapi.support.dto.response.UserResponse;
+import com.dobugs.yologaauthenticationapi.support.dto.response.OAuthTokenResponse;
+import com.dobugs.yologaauthenticationapi.support.dto.response.OAuthUserResponse;
 import com.dobugs.yologaauthenticationapi.support.exception.OAuthConnectionException;
 
 import lombok.Getter;
@@ -31,23 +31,23 @@ public class KakaoConnector implements OAuthConnector {
     }
 
     @Override
-    public TokenResponse requestToken(final String authorizationCode, final String redirectUrl) {
+    public OAuthTokenResponse requestToken(final String authorizationCode, final String redirectUrl) {
         final KakaoTokenResponse response = connectForToken(authorizationCode, redirectUrl);
-        return new TokenResponse(response.access_token(), response.expires_in(), response.refresh_token(),
+        return new OAuthTokenResponse(response.access_token(), response.expires_in(), response.refresh_token(),
             response.refresh_token_expires_in(), response.token_type());
     }
 
     @Override
-    public UserResponse requestUserInfo(final String tokenType, final String accessToken) {
+    public OAuthUserResponse requestUserInfo(final String tokenType, final String accessToken) {
         final KakaoUserResponse response = connectForUserInfo(tokenType, accessToken);
-        return new UserResponse(response.id());
+        return new OAuthUserResponse(response.id());
     }
 
     @Override
-    public TokenResponse requestAccessToken(final String refreshToken) {
+    public OAuthTokenResponse requestAccessToken(final String refreshToken) {
         final KakaoTokenResponse response = connectForAccessToken(refreshToken);
         final String returnedRefreshToken = selectRefreshToken(refreshToken, response);
-        return new TokenResponse(response.access_token(), response.expires_in(), returnedRefreshToken,
+        return new OAuthTokenResponse(response.access_token(), response.expires_in(), returnedRefreshToken,
             response.refresh_token_expires_in(), response.token_type());
     }
 

--- a/src/test/java/com/dobugs/yologaauthenticationapi/controller/AuthControllerTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/controller/AuthControllerTest.java
@@ -28,7 +28,7 @@ import org.springframework.util.MultiValueMap;
 import com.dobugs.yologaauthenticationapi.service.AuthService;
 import com.dobugs.yologaauthenticationapi.service.dto.request.OAuthCodeRequest;
 import com.dobugs.yologaauthenticationapi.service.dto.response.OAuthLinkResponse;
-import com.dobugs.yologaauthenticationapi.service.dto.response.OAuthTokenResponse;
+import com.dobugs.yologaauthenticationapi.service.dto.response.ServiceTokenResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @AutoConfigureMockMvc
@@ -86,7 +86,7 @@ class AuthControllerTest {
         final OAuthCodeRequest request = new OAuthCodeRequest("authorizationCode");
         final String body = objectMapper.writeValueAsString(request);
 
-        final OAuthTokenResponse response = new OAuthTokenResponse("accessToken", "refreshToken");
+        final ServiceTokenResponse response = new ServiceTokenResponse("accessToken", "refreshToken");
         given(authService.login(any(), any())).willReturn(response);
 
         mockMvc.perform(post(BASIC_URL + "/login")
@@ -108,7 +108,7 @@ class AuthControllerTest {
         final String accessToken = "accessToken";
         final String refreshToken = "refreshToken";
 
-        final OAuthTokenResponse response = new OAuthTokenResponse(accessToken, refreshToken);
+        final ServiceTokenResponse response = new ServiceTokenResponse(accessToken, refreshToken);
         given(authService.reissue(refreshToken)).willReturn(response);
 
         mockMvc.perform(post(BASIC_URL + "/reissue")

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/AuthServiceTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/AuthServiceTest.java
@@ -26,11 +26,11 @@ import com.dobugs.yologaauthenticationapi.repository.TokenRepository;
 import com.dobugs.yologaauthenticationapi.service.dto.request.OAuthCodeRequest;
 import com.dobugs.yologaauthenticationapi.service.dto.request.OAuthRequest;
 import com.dobugs.yologaauthenticationapi.service.dto.response.OAuthLinkResponse;
-import com.dobugs.yologaauthenticationapi.service.dto.response.OAuthTokenResponse;
+import com.dobugs.yologaauthenticationapi.service.dto.response.ServiceTokenResponse;
 import com.dobugs.yologaauthenticationapi.support.FakeOAuthConnector;
 import com.dobugs.yologaauthenticationapi.support.OAuthConnector;
 import com.dobugs.yologaauthenticationapi.support.TokenGenerator;
-import com.dobugs.yologaauthenticationapi.support.dto.response.ServiceTokenResponse;
+import com.dobugs.yologaauthenticationapi.support.dto.response.ServiceTokenDto;
 import com.dobugs.yologaauthenticationapi.support.dto.response.UserTokenResponse;
 
 import io.jsonwebtoken.Jwts;
@@ -101,9 +101,9 @@ class AuthServiceTest {
             final OAuthCodeRequest codeRequest = new OAuthCodeRequest("authorizationCode");
 
             given(memberRepository.findByOauthId(any())).willReturn(Optional.of(new Member("oauthId")));
-            given(tokenGenerator.create(any(), eq(provider), any())).willReturn(new ServiceTokenResponse(ACCESS_TOKEN, REFRESH_TOKEN));
+            given(tokenGenerator.create(any(), eq(provider), any())).willReturn(new ServiceTokenDto(ACCESS_TOKEN, REFRESH_TOKEN));
 
-            final OAuthTokenResponse response = authService.login(request, codeRequest);
+            final ServiceTokenResponse response = authService.login(request, codeRequest);
 
             assertAll(
                 () -> assertThat(response.accessToken()).isEqualTo(ACCESS_TOKEN),
@@ -131,9 +131,9 @@ class AuthServiceTest {
             final OAuthCodeRequest codeRequest = new OAuthCodeRequest("authorizationCode");
 
             given(memberRepository.findByOauthId(any())).willReturn(Optional.empty());
-            given(tokenGenerator.create(any(), eq(provider), any())).willReturn(new ServiceTokenResponse(ACCESS_TOKEN, REFRESH_TOKEN));
+            given(tokenGenerator.create(any(), eq(provider), any())).willReturn(new ServiceTokenDto(ACCESS_TOKEN, REFRESH_TOKEN));
 
-            final OAuthTokenResponse response = authService.login(request, codeRequest);
+            final ServiceTokenResponse response = authService.login(request, codeRequest);
 
             assertAll(
                 () -> assertThat(response.accessToken()).isEqualTo(ACCESS_TOKEN),
@@ -157,7 +157,7 @@ class AuthServiceTest {
             given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(memberId, provider, refreshToken));
             given(tokenRepository.exist(memberId)).willReturn(true);
             given(tokenRepository.existRefreshToken(memberId, refreshToken)).willReturn(true);
-            given(tokenGenerator.create(eq(memberId), eq(provider), any())).willReturn(new ServiceTokenResponse("accessToken", "refreshToken"));
+            given(tokenGenerator.create(eq(memberId), eq(provider), any())).willReturn(new ServiceTokenDto("accessToken", "refreshToken"));
 
             assertThatCode(() -> authService.reissue(serviceToken))
                 .doesNotThrowAnyException();

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/AuthServiceTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/AuthServiceTest.java
@@ -30,6 +30,7 @@ import com.dobugs.yologaauthenticationapi.service.dto.response.ServiceTokenRespo
 import com.dobugs.yologaauthenticationapi.support.FakeOAuthConnector;
 import com.dobugs.yologaauthenticationapi.support.OAuthConnector;
 import com.dobugs.yologaauthenticationapi.support.TokenGenerator;
+import com.dobugs.yologaauthenticationapi.support.dto.response.OAuthTokenDto;
 import com.dobugs.yologaauthenticationapi.support.dto.response.ServiceTokenDto;
 import com.dobugs.yologaauthenticationapi.support.dto.response.UserTokenResponse;
 
@@ -101,6 +102,7 @@ class AuthServiceTest {
             final OAuthCodeRequest codeRequest = new OAuthCodeRequest("authorizationCode");
 
             given(memberRepository.findByOauthId(any())).willReturn(Optional.of(new Member("oauthId")));
+            given(tokenGenerator.setUpRefreshTokenExpiration(any())).willReturn(new OAuthTokenDto(ACCESS_TOKEN, 1000, REFRESH_TOKEN, 1000, "Bearer"));
             given(tokenGenerator.create(any(), eq(provider), any())).willReturn(new ServiceTokenDto(ACCESS_TOKEN, REFRESH_TOKEN));
 
             final ServiceTokenResponse response = authService.login(request, codeRequest);
@@ -131,6 +133,7 @@ class AuthServiceTest {
             final OAuthCodeRequest codeRequest = new OAuthCodeRequest("authorizationCode");
 
             given(memberRepository.findByOauthId(any())).willReturn(Optional.empty());
+            given(tokenGenerator.setUpRefreshTokenExpiration(any())).willReturn(new OAuthTokenDto(ACCESS_TOKEN, 1000, REFRESH_TOKEN, 1000, "Bearer"));
             given(tokenGenerator.create(any(), eq(provider), any())).willReturn(new ServiceTokenDto(ACCESS_TOKEN, REFRESH_TOKEN));
 
             final ServiceTokenResponse response = authService.login(request, codeRequest);
@@ -157,6 +160,7 @@ class AuthServiceTest {
             given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(memberId, provider, refreshToken));
             given(tokenRepository.exist(memberId)).willReturn(true);
             given(tokenRepository.existRefreshToken(memberId, refreshToken)).willReturn(true);
+            given(tokenGenerator.setUpRefreshTokenExpiration(any())).willReturn(new OAuthTokenDto("accessToken", 1000, "refreshToken", 1000, "Bearer"));
             given(tokenGenerator.create(eq(memberId), eq(provider), any())).willReturn(new ServiceTokenDto("accessToken", "refreshToken"));
 
             assertThatCode(() -> authService.reissue(serviceToken))

--- a/src/test/java/com/dobugs/yologaauthenticationapi/support/FakeOAuthConnector.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/support/FakeOAuthConnector.java
@@ -1,7 +1,7 @@
 package com.dobugs.yologaauthenticationapi.support;
 
-import com.dobugs.yologaauthenticationapi.support.dto.response.TokenResponse;
-import com.dobugs.yologaauthenticationapi.support.dto.response.UserResponse;
+import com.dobugs.yologaauthenticationapi.support.dto.response.OAuthTokenResponse;
+import com.dobugs.yologaauthenticationapi.support.dto.response.OAuthUserResponse;
 
 public class FakeOAuthConnector implements OAuthConnector {
 
@@ -13,8 +13,8 @@ public class FakeOAuthConnector implements OAuthConnector {
     }
 
     @Override
-    public TokenResponse requestToken(final String authorizationCode, final String redirectUrl) {
-        return new TokenResponse(
+    public OAuthTokenResponse requestToken(final String authorizationCode, final String redirectUrl) {
+        return new OAuthTokenResponse(
             "accessToken", 1_000,
             "refreshToken", 10_000,
             "Bearer"
@@ -22,13 +22,13 @@ public class FakeOAuthConnector implements OAuthConnector {
     }
 
     @Override
-    public UserResponse requestUserInfo(final String tokenType, final String accessToken) {
-        return new UserResponse(String.valueOf(123456789));
+    public OAuthUserResponse requestUserInfo(final String tokenType, final String accessToken) {
+        return new OAuthUserResponse(String.valueOf(123456789));
     }
 
     @Override
-    public TokenResponse requestAccessToken(final String refreshToken) {
-        return new TokenResponse(
+    public OAuthTokenResponse requestAccessToken(final String refreshToken) {
+        return new OAuthTokenResponse(
             "accessToken", 1_000,
             "refreshToken", 10_000,
             "Bearer"

--- a/src/test/java/com/dobugs/yologaauthenticationapi/support/TokenGeneratorTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/support/TokenGeneratorTest.java
@@ -15,8 +15,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import com.dobugs.yologaauthenticationapi.domain.Provider;
-import com.dobugs.yologaauthenticationapi.support.dto.response.TokenResponse;
-import com.dobugs.yologaauthenticationapi.support.dto.response.ServiceTokenResponse;
+import com.dobugs.yologaauthenticationapi.support.dto.response.OAuthTokenResponse;
+import com.dobugs.yologaauthenticationapi.support.dto.response.ServiceTokenDto;
 import com.dobugs.yologaauthenticationapi.support.dto.response.UserTokenResponse;
 
 import io.jsonwebtoken.ExpiredJwtException;
@@ -53,14 +53,14 @@ class TokenGeneratorTest {
         @DisplayName("token 을 생성한다")
         @Test
         void success() {
-            final TokenResponse tokenResponse = new TokenResponse(ACCESS_TOKEN, EXPIRES_IN, REFRESH_TOKEN, EXPIRES_IN, "bearer");
+            final OAuthTokenResponse oAuthTokenResponse = new OAuthTokenResponse(ACCESS_TOKEN, EXPIRES_IN, REFRESH_TOKEN, EXPIRES_IN, "bearer");
 
-            final ServiceTokenResponse serviceTokenResponse = tokenGenerator.create(MEMBER_ID, PROVIDER, tokenResponse);
+            final ServiceTokenDto serviceTokenDto = tokenGenerator.create(MEMBER_ID, PROVIDER, oAuthTokenResponse);
 
-            final Integer memberId = extractMemberId(serviceTokenResponse.accessToken());
-            final String accessToken = extractToken(serviceTokenResponse.accessToken());
-            final String refreshToken = extractToken(serviceTokenResponse.refreshToken());
-            final String provider = extractProvider(serviceTokenResponse.accessToken());
+            final Integer memberId = extractMemberId(serviceTokenDto.accessToken());
+            final String accessToken = extractToken(serviceTokenDto.accessToken());
+            final String refreshToken = extractToken(serviceTokenDto.refreshToken());
+            final String provider = extractProvider(serviceTokenDto.accessToken());
             assertAll(
                 () -> assertThat(memberId).isEqualTo(MEMBER_ID),
                 () -> assertThat(accessToken).isEqualTo(ACCESS_TOKEN),


### PR DESCRIPTION
## *관련 작업 티켓

- https://dobugs.atlassian.net/browse/YOL-172

## *작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- 구글로 로그인한 계정의 access token 재발급이 되지 않는다는 문제를 발견하였습니다.
- 디버깅 결과 구글 계정의 재발급 요청을 보낼 경우 Redis 에 refresh token 이 저장되지 않아 응답으로 로그인 요청을 반환하였습니다.
- **구글**에서 OAuth2.0 로그인 시 받아오는 refresh token 의 만료 시간은 `-1` 로 무제한입니다.
- Redis 에서도 `-1` 이 만료 시간 무제한을 의미하지만 직접 -1 로 설정 후 저장하면 저장이 되지 않습니다.
  - 별도의 설정 없이 값을 저장할 경우 만료 시간이 -1 입니다.
- 따라서 Redis 에 저장하기 전에 refresh token 의 만료 시간을 재설정하였습니다.
- 또한 Controller 계층에서 사용하는 DTO 와 그 외의 계층에서 생성하는 DTO 가 늘어남에 따라 이름을 변경하였습니다.
  - Controller 에서 받아온 DTO -> XXXRequest
  - Controller 에 응답하는 DTO -> XXXResponse
  - 외부 서버에서 받아온 DTO -> XXXResponse
  - Controller 가 아닌 다른 계층에서 생성한 DTO -> XXXDto

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)
