### PR TITLE
fix: S3 파일 업로드 시 사용하는 메서드 변경

### DIFF
--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/resource/S3Connector.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/resource/S3Connector.java
@@ -30,7 +30,7 @@ public class S3Connector implements StorageConnector {
     public ResourceResponse save(final MultipartFile resource, final String path, final String resourceName) {
         final String resourceKey = concatResourceKey(path, resourceName);
         final ByteArrayInputStream serializedResource = serialize(resource);
-        final S3Resource savedResource = s3Template.store(s3Provider.bucket(), resourceKey, serializedResource);
+        final S3Resource savedResource = s3Template.upload(s3Provider.bucket(), resourceKey, serializedResource);
         return createResourceResponse(resourceKey, savedResource);
     }
 

--- a/src/test/java/com/dobugs/yologaauthenticationapi/support/resource/S3ConnectorTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/support/resource/S3ConnectorTest.java
@@ -67,7 +67,7 @@ class S3ConnectorTest {
 
             final S3Resource s3Resource = mock(S3Resource.class);
             given(s3Resource.getURL()).willReturn(new URL("http", "localhost", 8080, resourceName));
-            given(s3Template.store(eq(fakeStorageProvider.bucket()), eq(resourceName), any())).willReturn(s3Resource);
+            given(s3Template.upload(eq(fakeStorageProvider.bucket()), eq(resourceName), any())).willReturn(s3Resource);
 
             final ResourceResponse response = s3Connector.save(resource, path, resourceName);
 
@@ -91,7 +91,7 @@ class S3ConnectorTest {
                 final S3Resource s3Resource = mock(S3Resource.class);
                 final S3Template s3Template = mock(S3Template.class);
                 given(s3Resource.getURL()).willReturn(new URL("https", "host", 1234, "file"));
-                given(s3Template.store(any(), any(), any())).willReturn(s3Resource);
+                given(s3Template.upload(any(), any(), any())).willReturn(s3Resource);
 
                 s3Connector = new S3Connector(s3Template, new FakeStorageProvider());
             }


### PR DESCRIPTION
## *관련 작업 티켓

- https://dobugs.atlassian.net/browse/YOL-173

## *작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- S3Template 에서 제공하는 메서드를 잘못 사용하고 있어 이를 수정하였습니다.
  - 기존) S3Template#store : `Java 객체` 를 JSON 으로 직렬화하여 저장
  - 변경) S3Template#upload : `파일` 을 저장

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)
