### PR TITLE
refactor: OAuth2.0 토큰 만료시간 통일, OAuth2.0 로그아웃 기능 구현

### DIFF
--- a/src/main/java/com/dobugs/yologaauthenticationapi/domain/OAuthToken.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/domain/OAuthToken.java
@@ -12,7 +12,6 @@ import lombok.Getter;
 public class OAuthToken {
 
     public static final String KEY_NAME_OF_PROVIDER = "provider";
-    public static final String KEY_NAME_OF_ACCESS_TOKEN = "accessToken";
     public static final String KEY_NAME_OF_REFRESH_TOKEN = "refreshToken";
 
     @Id

--- a/src/main/java/com/dobugs/yologaauthenticationapi/repository/TokenRepository.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/repository/TokenRepository.java
@@ -12,7 +12,7 @@ import com.dobugs.yologaauthenticationapi.domain.OAuthToken;
 @Repository
 public class TokenRepository {
 
-    private static final TimeUnit DEFAULT_TIME_UNIT = TimeUnit.SECONDS;
+    private static final TimeUnit DEFAULT_TIME_UNIT = TimeUnit.MILLISECONDS;
     private static final long INFINITE_EXPIRATION = -1L;
     private static final long DELETED = -2L;
 

--- a/src/main/java/com/dobugs/yologaauthenticationapi/repository/TokenRepository.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/repository/TokenRepository.java
@@ -28,7 +28,6 @@ public class TokenRepository {
         final String key = String.valueOf(oAuthToken.getMemberId());
         final HashMap<String, Object> value = new HashMap<>();
         value.put(OAuthToken.KEY_NAME_OF_PROVIDER, oAuthToken.getProvider().getName());
-        value.put(OAuthToken.KEY_NAME_OF_ACCESS_TOKEN, oAuthToken.getAccessToken());
         value.put(OAuthToken.KEY_NAME_OF_REFRESH_TOKEN, oAuthToken.getRefreshToken());
 
         operations.putAll(key, value);
@@ -47,7 +46,7 @@ public class TokenRepository {
 
     public void delete(final Long memberId) {
         operations.delete(String.valueOf(memberId),
-            OAuthToken.KEY_NAME_OF_PROVIDER, OAuthToken.KEY_NAME_OF_ACCESS_TOKEN, OAuthToken.KEY_NAME_OF_REFRESH_TOKEN
+            OAuthToken.KEY_NAME_OF_PROVIDER, OAuthToken.KEY_NAME_OF_REFRESH_TOKEN
         );
     }
 

--- a/src/main/java/com/dobugs/yologaauthenticationapi/repository/TokenRepository.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/repository/TokenRepository.java
@@ -1,6 +1,7 @@
 package com.dobugs.yologaauthenticationapi.repository;
 
 import java.util.HashMap;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.data.redis.core.HashOperations;
@@ -44,21 +45,15 @@ public class TokenRepository {
         }
     }
 
+    public Optional<String> findRefreshToken(final Long memberId) {
+        final String key = String.valueOf(memberId);
+        return Optional.ofNullable((String) operations.get(key, OAuthToken.KEY_NAME_OF_REFRESH_TOKEN));
+    }
+
     public void delete(final Long memberId) {
         operations.delete(String.valueOf(memberId),
             OAuthToken.KEY_NAME_OF_PROVIDER, OAuthToken.KEY_NAME_OF_REFRESH_TOKEN
         );
-    }
-
-    public boolean exist(final Long memberId) {
-        final String key = String.valueOf(memberId);
-        return operations.hasKey(key, OAuthToken.KEY_NAME_OF_REFRESH_TOKEN);
-    }
-
-    public boolean existRefreshToken(final Long memberId, final String refreshToken) {
-        final String key = String.valueOf(memberId);
-        final String savedRefreshToken = (String) operations.get(key, OAuthToken.KEY_NAME_OF_REFRESH_TOKEN);
-        return refreshToken.equals(savedRefreshToken);
     }
 
     private boolean isAbleToReconfigureExpiration(final Long expiration) {

--- a/src/main/java/com/dobugs/yologaauthenticationapi/service/AuthService.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/service/AuthService.java
@@ -17,6 +17,7 @@ import com.dobugs.yologaauthenticationapi.service.dto.response.OAuthLinkResponse
 import com.dobugs.yologaauthenticationapi.service.dto.response.ServiceTokenResponse;
 import com.dobugs.yologaauthenticationapi.support.OAuthConnector;
 import com.dobugs.yologaauthenticationapi.support.TokenGenerator;
+import com.dobugs.yologaauthenticationapi.support.dto.request.OAuthLogoutRequest;
 import com.dobugs.yologaauthenticationapi.support.dto.response.OAuthTokenDto;
 import com.dobugs.yologaauthenticationapi.support.dto.response.ServiceTokenDto;
 import com.dobugs.yologaauthenticationapi.support.dto.response.OAuthTokenResponse;
@@ -80,9 +81,11 @@ public class AuthService {
         final OAuthConnector oAuthConnector = selectConnector(userTokenResponse.provider());
         final Long memberId = userTokenResponse.memberId();
 
+        final String accessToken = userTokenResponse.token();
         final String refreshToken = findRefreshToken(memberId);
+        final String tokenType = userTokenResponse.tokenType();
         tokenRepository.delete(memberId);
-        oAuthConnector.logout(refreshToken);
+        oAuthConnector.logout(new OAuthLogoutRequest(accessToken, refreshToken, tokenType));
     }
 
     private Long saveMember(final String provider, final OAuthTokenDto oAuthTokenDto, final OAuthUserResponse OAuthUserResponse) {

--- a/src/main/java/com/dobugs/yologaauthenticationapi/service/AuthService.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/service/AuthService.java
@@ -55,7 +55,7 @@ public class AuthService {
         final OAuthTokenResponse oAuthTokenResponse = oAuthConnector.requestToken(authorizationCode, redirectUrl);
         final OAuthUserResponse oAuthUserResponse = oAuthConnector.requestUserInfo(oAuthTokenResponse.tokenType(), oAuthTokenResponse.accessToken());
 
-        final OAuthTokenDto oAuthTokenDto = tokenGenerator.setUpRefreshTokenExpiration(oAuthTokenResponse);
+        final OAuthTokenDto oAuthTokenDto = tokenGenerator.setUpExpiration(oAuthTokenResponse);
         final Long memberId = saveMember(provider, oAuthTokenDto, oAuthUserResponse);
         final ServiceTokenDto serviceTokenDto = tokenGenerator.create(memberId, provider, oAuthTokenDto);
 
@@ -69,7 +69,7 @@ public class AuthService {
 
         validateTheExistenceOfRefreshToken(userTokenResponse.memberId(), refreshToken);
         final OAuthTokenResponse response = oAuthConnector.requestAccessToken(refreshToken);
-        final OAuthTokenDto oAuthTokenDto = tokenGenerator.setUpRefreshTokenExpiration(response);
+        final OAuthTokenDto oAuthTokenDto = tokenGenerator.setUpExpiration(response);
         restoreRefreshToken(userTokenResponse.memberId(), oAuthTokenDto.refreshToken());
         final ServiceTokenDto serviceTokenDto = tokenGenerator.create(userTokenResponse.memberId(), userTokenResponse.provider(), oAuthTokenDto);
         return new ServiceTokenResponse(serviceTokenDto.accessToken(), serviceTokenDto.refreshToken());
@@ -106,7 +106,7 @@ public class AuthService {
     private void saveMemberToRedis(final String provider, final OAuthTokenDto oAuthTokenDto, final Member savedMember) {
         final OAuthToken oAuthToken = OAuthToken.login(
             savedMember.getId(), Provider.findOf(provider),
-            oAuthTokenDto.refreshToken(), (long) oAuthTokenDto.refreshTokenExpiresIn()
+            oAuthTokenDto.refreshToken(), oAuthTokenDto.refreshTokenExpiresIn()
         );
         tokenRepository.save(oAuthToken);
     }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/OAuthConnector.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/OAuthConnector.java
@@ -16,4 +16,6 @@ public interface OAuthConnector {
     OAuthUserResponse requestUserInfo(String tokenType, String accessToken);
 
     OAuthTokenResponse requestAccessToken(String refreshToken);
+
+    void logout(String token);
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/OAuthConnector.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/OAuthConnector.java
@@ -2,6 +2,7 @@ package com.dobugs.yologaauthenticationapi.support;
 
 import org.springframework.web.client.RestTemplate;
 
+import com.dobugs.yologaauthenticationapi.support.dto.request.OAuthLogoutRequest;
 import com.dobugs.yologaauthenticationapi.support.dto.response.OAuthTokenResponse;
 import com.dobugs.yologaauthenticationapi.support.dto.response.OAuthUserResponse;
 
@@ -17,5 +18,5 @@ public interface OAuthConnector {
 
     OAuthTokenResponse requestAccessToken(String refreshToken);
 
-    void logout(String token);
+    void logout(OAuthLogoutRequest oAuthLogoutRequest);
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/OAuthProvider.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/OAuthProvider.java
@@ -24,7 +24,7 @@ public interface OAuthProvider {
 
     HttpEntity<MultiValueMap<String, String>> createAccessTokenEntity();
 
-    HttpEntity<MultiValueMap<String, String>> createLogoutEntity();
+    HttpEntity<MultiValueMap<String, String>> createLogoutEntity(String tokenType, String token);
 
     default String concatParams(final Map<String, String> params) {
         return params.entrySet()

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/OAuthProvider.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/OAuthProvider.java
@@ -16,11 +16,15 @@ public interface OAuthProvider {
 
     String generateAccessTokenUrl(String refreshToken);
 
+    String generateRevokeToken(String token);
+
     HttpEntity<MultiValueMap<String, String>> createTokenEntity();
 
     HttpEntity<MultiValueMap<String, String>> createUserEntity(String tokenType, String accessToken);
 
     HttpEntity<MultiValueMap<String, String>> createAccessTokenEntity();
+
+    HttpEntity<MultiValueMap<String, String>> createLogoutEntity();
 
     default String concatParams(final Map<String, String> params) {
         return params.entrySet()

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/OAuthProvider.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/OAuthProvider.java
@@ -16,7 +16,7 @@ public interface OAuthProvider {
 
     String generateAccessTokenUrl(String refreshToken);
 
-    String generateRevokeToken(String token);
+    String generateLogoutUrl(String token);
 
     HttpEntity<MultiValueMap<String, String>> createTokenEntity();
 

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/TokenGenerator.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/TokenGenerator.java
@@ -21,6 +21,7 @@ import io.jsonwebtoken.security.Keys;
 @Component
 public class TokenGenerator {
 
+    private static final String SERVICE_TOKEN_TYPE = "Bearer ";
     private static final String PAYLOAD_NAME_OF_MEMBER_ID = "memberId";
     private static final String PAYLOAD_NAME_OF_PROVIDER = "provider";
     private static final String PAYLOAD_NAME_OF_TOKEN_TYPE = "tokenType";
@@ -47,7 +48,7 @@ public class TokenGenerator {
     }
 
     public UserTokenResponse extract(final String serviceToken) {
-        final String jwt = serviceToken.replace("Bearer ", "");
+        final String jwt = serviceToken.replace(SERVICE_TOKEN_TYPE, "");
         final Claims claims = extractClaims(jwt);
         final Long memberId = extractMemberId(claims);
         final String provider = extractProvider(claims);

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/request/OAuthLogoutRequest.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/request/OAuthLogoutRequest.java
@@ -1,0 +1,4 @@
+package com.dobugs.yologaauthenticationapi.support.dto.request;
+
+public record OAuthLogoutRequest(String accessToken, String refreshToken, String tokenType) {
+}

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/response/OAuthLogoutResponse.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/response/OAuthLogoutResponse.java
@@ -1,4 +1,4 @@
 package com.dobugs.yologaauthenticationapi.support.dto.response;
 
-public record OAuthRevokeResponse() {
+public record OAuthLogoutResponse() {
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/response/OAuthRevokeResponse.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/response/OAuthRevokeResponse.java
@@ -1,0 +1,4 @@
+package com.dobugs.yologaauthenticationapi.support.dto.response;
+
+public record OAuthRevokeResponse() {
+}

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/response/OAuthTokenDto.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/response/OAuthTokenDto.java
@@ -1,4 +1,4 @@
 package com.dobugs.yologaauthenticationapi.support.dto.response;
 
-public record OAuthTokenDto(String accessToken, int expiresIn, String refreshToken, int refreshTokenExpiresIn, String tokenType) {
+public record OAuthTokenDto(String accessToken, long expiresIn, String refreshToken, long refreshTokenExpiresIn, String tokenType) {
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/response/UserTokenResponse.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/dto/response/UserTokenResponse.java
@@ -1,4 +1,4 @@
 package com.dobugs.yologaauthenticationapi.support.dto.response;
 
-public record UserTokenResponse(Long memberId, String provider, String token) {
+public record UserTokenResponse(Long memberId, String provider, String tokenType, String token) {
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleConnector.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleConnector.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 
 import com.dobugs.yologaauthenticationapi.support.OAuthConnector;
 import com.dobugs.yologaauthenticationapi.support.OAuthProvider;
+import com.dobugs.yologaauthenticationapi.support.dto.request.OAuthLogoutRequest;
 import com.dobugs.yologaauthenticationapi.support.dto.response.GoogleTokenResponse;
 import com.dobugs.yologaauthenticationapi.support.dto.response.GoogleUserResponse;
 import com.dobugs.yologaauthenticationapi.support.dto.response.OAuthLogoutResponse;
@@ -54,8 +55,8 @@ public class GoogleConnector implements OAuthConnector {
     }
 
     @Override
-    public void logout(final String token) {
-        connectForLogout(token);
+    public void logout(final OAuthLogoutRequest oAuthLogoutRequest) {
+        connectForLogout(oAuthLogoutRequest.refreshToken(), oAuthLogoutRequest.tokenType());
     }
 
     private GoogleTokenResponse connectForToken(final String authorizationCode, final String redirectUrl) {
@@ -92,10 +93,10 @@ public class GoogleConnector implements OAuthConnector {
             .orElseThrow(() -> new OAuthConnectionException("Google 에서 Access Token 을 재발급 받는 과정에서 연결에 실패하였습니다."));
     }
 
-    private void connectForLogout(final String token) {
+    private void connectForLogout(final String refreshToken, final String tokenType) {
         final ResponseEntity<OAuthLogoutResponse> response = REST_TEMPLATE.postForEntity(
-            googleProvider.generateLogoutUrl(token),
-            googleProvider.createLogoutEntity(),
+            googleProvider.generateLogoutUrl(refreshToken),
+            googleProvider.createLogoutEntity(tokenType, refreshToken),
             OAuthLogoutResponse.class
         );
         validateConnectionResponseIsSuccess(response);

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleConnector.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleConnector.java
@@ -11,6 +11,7 @@ import com.dobugs.yologaauthenticationapi.support.OAuthConnector;
 import com.dobugs.yologaauthenticationapi.support.OAuthProvider;
 import com.dobugs.yologaauthenticationapi.support.dto.response.GoogleTokenResponse;
 import com.dobugs.yologaauthenticationapi.support.dto.response.GoogleUserResponse;
+import com.dobugs.yologaauthenticationapi.support.dto.response.OAuthRevokeResponse;
 import com.dobugs.yologaauthenticationapi.support.dto.response.OAuthTokenResponse;
 import com.dobugs.yologaauthenticationapi.support.dto.response.OAuthUserResponse;
 import com.dobugs.yologaauthenticationapi.support.exception.OAuthConnectionException;
@@ -52,6 +53,11 @@ public class GoogleConnector implements OAuthConnector {
             REFRESH_TOKEN_EXPIRES_IN, response.token_type());
     }
 
+    @Override
+    public void logout(final String token) {
+        connectForRevokeToken(token);
+    }
+
     private GoogleTokenResponse connectForToken(final String authorizationCode, final String redirectUrl) {
         final ResponseEntity<GoogleTokenResponse> response = REST_TEMPLATE.postForEntity(
             googleProvider.generateTokenUrl(authorizationCode, redirectUrl),
@@ -84,6 +90,15 @@ public class GoogleConnector implements OAuthConnector {
         validateConnectionResponseIsSuccess(response);
         return Optional.ofNullable(response.getBody())
             .orElseThrow(() -> new OAuthConnectionException("Google 에서 Access Token 을 재발급 받는 과정에서 연결에 실패하였습니다."));
+    }
+
+    private void connectForRevokeToken(final String token) {
+        final ResponseEntity<OAuthRevokeResponse> response = REST_TEMPLATE.postForEntity(
+            googleProvider.generateRevokeToken(token),
+            googleProvider.createLogoutEntity(),
+            OAuthRevokeResponse.class
+        );
+        validateConnectionResponseIsSuccess(response);
     }
 
     private void validateConnectionResponseIsSuccess(final ResponseEntity<?> response) {

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleConnector.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleConnector.java
@@ -11,7 +11,7 @@ import com.dobugs.yologaauthenticationapi.support.OAuthConnector;
 import com.dobugs.yologaauthenticationapi.support.OAuthProvider;
 import com.dobugs.yologaauthenticationapi.support.dto.response.GoogleTokenResponse;
 import com.dobugs.yologaauthenticationapi.support.dto.response.GoogleUserResponse;
-import com.dobugs.yologaauthenticationapi.support.dto.response.OAuthRevokeResponse;
+import com.dobugs.yologaauthenticationapi.support.dto.response.OAuthLogoutResponse;
 import com.dobugs.yologaauthenticationapi.support.dto.response.OAuthTokenResponse;
 import com.dobugs.yologaauthenticationapi.support.dto.response.OAuthUserResponse;
 import com.dobugs.yologaauthenticationapi.support.exception.OAuthConnectionException;
@@ -55,7 +55,7 @@ public class GoogleConnector implements OAuthConnector {
 
     @Override
     public void logout(final String token) {
-        connectForRevokeToken(token);
+        connectForLogout(token);
     }
 
     private GoogleTokenResponse connectForToken(final String authorizationCode, final String redirectUrl) {
@@ -92,11 +92,11 @@ public class GoogleConnector implements OAuthConnector {
             .orElseThrow(() -> new OAuthConnectionException("Google 에서 Access Token 을 재발급 받는 과정에서 연결에 실패하였습니다."));
     }
 
-    private void connectForRevokeToken(final String token) {
-        final ResponseEntity<OAuthRevokeResponse> response = REST_TEMPLATE.postForEntity(
-            googleProvider.generateRevokeToken(token),
+    private void connectForLogout(final String token) {
+        final ResponseEntity<OAuthLogoutResponse> response = REST_TEMPLATE.postForEntity(
+            googleProvider.generateLogoutUrl(token),
             googleProvider.createLogoutEntity(),
-            OAuthRevokeResponse.class
+            OAuthLogoutResponse.class
         );
         validateConnectionResponseIsSuccess(response);
     }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleProvider.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleProvider.java
@@ -25,6 +25,7 @@ public class GoogleProvider implements OAuthProvider {
     private final String authUrl;
     private final String accessTokenUrl;
     private final String userInfoUrl;
+    private final String logoutUrl;
     private final String grantType;
 
     public GoogleProvider(
@@ -35,6 +36,7 @@ public class GoogleProvider implements OAuthProvider {
         @Value("${oauth2.google.url.auth}") final String authUrl,
         @Value("${oauth2.google.url.token}") final String accessTokenUrl,
         @Value("${oauth2.google.url.userinfo}") final String userInfoUrl,
+        @Value("${oauth2.google.url.logout}") final String logoutUrl,
         @Value("${oauth2.google.grant-type}") final String grantType
     ) {
         this.clientId = clientId;
@@ -44,6 +46,7 @@ public class GoogleProvider implements OAuthProvider {
         this.authUrl = authUrl;
         this.accessTokenUrl = accessTokenUrl;
         this.userInfoUrl = userInfoUrl;
+        this.logoutUrl = logoutUrl;
         this.grantType = grantType;
     }
 
@@ -86,6 +89,13 @@ public class GoogleProvider implements OAuthProvider {
     }
 
     @Override
+    public String generateRevokeToken(final String token) {
+        final Map<String, String> params = new HashMap<>();
+        params.put("token", token);
+        return logoutUrl + "?" + concatParams(params);
+    }
+
+    @Override
     public HttpEntity<MultiValueMap<String, String>> createTokenEntity() {
         return new HttpEntity<>(createTokenHeaders());
     }
@@ -97,6 +107,11 @@ public class GoogleProvider implements OAuthProvider {
 
     @Override
     public HttpEntity<MultiValueMap<String, String>> createAccessTokenEntity() {
+        return new HttpEntity<>(createTokenHeaders());
+    }
+
+    @Override
+    public HttpEntity<MultiValueMap<String, String>> createLogoutEntity() {
         return new HttpEntity<>(createTokenHeaders());
     }
 

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleProvider.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleProvider.java
@@ -111,7 +111,7 @@ public class GoogleProvider implements OAuthProvider {
     }
 
     @Override
-    public HttpEntity<MultiValueMap<String, String>> createLogoutEntity() {
+    public HttpEntity<MultiValueMap<String, String>> createLogoutEntity(final String tokenType, final String refreshToken) {
         return new HttpEntity<>(createTokenHeaders());
     }
 

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleProvider.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleProvider.java
@@ -97,32 +97,33 @@ public class GoogleProvider implements OAuthProvider {
 
     @Override
     public HttpEntity<MultiValueMap<String, String>> createTokenEntity() {
-        return new HttpEntity<>(createTokenHeaders());
+        return new HttpEntity<>(createBasicHeaders());
     }
 
     @Override
     public HttpEntity<MultiValueMap<String, String>> createUserEntity(final String tokenType, final String accessToken) {
-        return new HttpEntity<>(createUserHeaders(tokenType, accessToken));
+        return new HttpEntity<>(createAuthorizationHeaders(tokenType, accessToken));
     }
 
     @Override
     public HttpEntity<MultiValueMap<String, String>> createAccessTokenEntity() {
-        return new HttpEntity<>(createTokenHeaders());
+        return new HttpEntity<>(createBasicHeaders());
     }
 
     @Override
     public HttpEntity<MultiValueMap<String, String>> createLogoutEntity(final String tokenType, final String refreshToken) {
-        return new HttpEntity<>(createTokenHeaders());
+        return new HttpEntity<>(createBasicHeaders());
     }
 
-    private HttpHeaders createTokenHeaders() {
+    private HttpHeaders createBasicHeaders() {
         final HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
         return headers;
     }
 
-    private HttpHeaders createUserHeaders(final String tokenType, final String accessToken) {
+    private HttpHeaders createAuthorizationHeaders(final String tokenType, final String accessToken) {
         final HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
         headers.set("Authorization", String.join(" ", tokenType, accessToken));
         return headers;
     }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleProvider.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/google/GoogleProvider.java
@@ -89,7 +89,7 @@ public class GoogleProvider implements OAuthProvider {
     }
 
     @Override
-    public String generateRevokeToken(final String token) {
+    public String generateLogoutUrl(final String token) {
         final Map<String, String> params = new HashMap<>();
         params.put("token", token);
         return logoutUrl + "?" + concatParams(params);

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoConnector.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoConnector.java
@@ -51,6 +51,11 @@ public class KakaoConnector implements OAuthConnector {
             response.refresh_token_expires_in(), response.token_type());
     }
 
+    @Override
+    public void logout(final String token) {
+
+    }
+
     private KakaoTokenResponse connectForToken(final String authorizationCode, final String redirectUrl) {
         final ResponseEntity<KakaoTokenResponse> response = REST_TEMPLATE.postForEntity(
             kakaoProvider.generateTokenUrl(authorizationCode, redirectUrl),

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoConnector.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoConnector.java
@@ -9,8 +9,10 @@ import org.springframework.stereotype.Component;
 
 import com.dobugs.yologaauthenticationapi.support.OAuthConnector;
 import com.dobugs.yologaauthenticationapi.support.OAuthProvider;
+import com.dobugs.yologaauthenticationapi.support.dto.request.OAuthLogoutRequest;
 import com.dobugs.yologaauthenticationapi.support.dto.response.KakaoTokenResponse;
 import com.dobugs.yologaauthenticationapi.support.dto.response.KakaoUserResponse;
+import com.dobugs.yologaauthenticationapi.support.dto.response.OAuthLogoutResponse;
 import com.dobugs.yologaauthenticationapi.support.dto.response.OAuthTokenResponse;
 import com.dobugs.yologaauthenticationapi.support.dto.response.OAuthUserResponse;
 import com.dobugs.yologaauthenticationapi.support.exception.OAuthConnectionException;
@@ -52,8 +54,8 @@ public class KakaoConnector implements OAuthConnector {
     }
 
     @Override
-    public void logout(final String token) {
-
+    public void logout(final OAuthLogoutRequest oAuthLogoutRequest) {
+        connectForLogout(oAuthLogoutRequest.accessToken(), oAuthLogoutRequest.tokenType());
     }
 
     private KakaoTokenResponse connectForToken(final String authorizationCode, final String redirectUrl) {
@@ -88,6 +90,15 @@ public class KakaoConnector implements OAuthConnector {
         validateConnectionResponseIsSuccess(response);
         return Optional.ofNullable(response.getBody())
             .orElseThrow(() -> new OAuthConnectionException("kakao 에서 Access Token 을 재발급 받는 과정에서 연결에 실패하였습니다."));
+    }
+
+    private void connectForLogout(final String accessToken, final String tokenType) {
+        final ResponseEntity<OAuthLogoutResponse> response = REST_TEMPLATE.postForEntity(
+            kakaoProvider.generateLogoutUrl(accessToken),
+            kakaoProvider.createLogoutEntity(tokenType, accessToken),
+            OAuthLogoutResponse.class
+        );
+        validateConnectionResponseIsSuccess(response);
     }
 
     private String selectRefreshToken(final String refreshToken, final KakaoTokenResponse response) {

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoProvider.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoProvider.java
@@ -73,6 +73,11 @@ public class KakaoProvider implements OAuthProvider {
     }
 
     @Override
+    public String generateRevokeToken(final String token) {
+        return null;
+    }
+
+    @Override
     public HttpEntity<MultiValueMap<String, String>> createTokenEntity() {
         return new HttpEntity<>(createTokenHeaders());
     }
@@ -84,6 +89,11 @@ public class KakaoProvider implements OAuthProvider {
 
     @Override
     public HttpEntity<MultiValueMap<String, String>> createAccessTokenEntity() {
+        return new HttpEntity<>(createTokenHeaders());
+    }
+
+    @Override
+    public HttpEntity<MultiValueMap<String, String>> createLogoutEntity() {
         return new HttpEntity<>(createTokenHeaders());
     }
 

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoProvider.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoProvider.java
@@ -82,32 +82,33 @@ public class KakaoProvider implements OAuthProvider {
 
     @Override
     public HttpEntity<MultiValueMap<String, String>> createTokenEntity() {
-        return new HttpEntity<>(createTokenHeaders());
+        return new HttpEntity<>(createBasicHeaders());
     }
 
     @Override
     public HttpEntity<MultiValueMap<String, String>> createUserEntity(final String tokenType, final String accessToken) {
-        return new HttpEntity<>(createUserHeaders(tokenType, accessToken));
+        return new HttpEntity<>(createAuthorizationHeaders(tokenType, accessToken));
     }
 
     @Override
     public HttpEntity<MultiValueMap<String, String>> createAccessTokenEntity() {
-        return new HttpEntity<>(createTokenHeaders());
+        return new HttpEntity<>(createBasicHeaders());
     }
 
     @Override
     public HttpEntity<MultiValueMap<String, String>> createLogoutEntity(final String tokenType, final String accessToken) {
-        return new HttpEntity<>(createUserHeaders(tokenType, accessToken));
+        return new HttpEntity<>(createAuthorizationHeaders(tokenType, accessToken));
     }
 
-    private HttpHeaders createTokenHeaders() {
+    private HttpHeaders createBasicHeaders() {
         final HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
         return headers;
     }
 
-    private HttpHeaders createUserHeaders(final String tokenType, final String accessToken) {
+    private HttpHeaders createAuthorizationHeaders(final String tokenType, final String accessToken) {
         final HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
         headers.set("Authorization", String.join(" ", tokenType, accessToken));
         return headers;
     }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoProvider.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoProvider.java
@@ -22,6 +22,7 @@ public class KakaoProvider implements OAuthProvider {
     private final String authUrl;
     private final String accessTokenUrl;
     private final String userInfoUrl;
+    private final String logoutUrl;
     private final String grantType;
 
     public KakaoProvider(
@@ -29,12 +30,14 @@ public class KakaoProvider implements OAuthProvider {
         @Value("${oauth2.kakao.url.auth}") final String authUrl,
         @Value("${oauth2.kakao.url.token}") final String accessTokenUrl,
         @Value("${oauth2.kakao.url.userinfo}") final String userInfoUrl,
+        @Value("${oauth2.kakao.url.logout}") final String logoutUrl,
         @Value("${oauth2.kakao.grant-type}") final String grantType
     ) {
         this.clientId = clientId;
         this.authUrl = authUrl;
         this.accessTokenUrl = accessTokenUrl;
         this.userInfoUrl = userInfoUrl;
+        this.logoutUrl = logoutUrl;
         this.grantType = grantType;
     }
 
@@ -74,7 +77,7 @@ public class KakaoProvider implements OAuthProvider {
 
     @Override
     public String generateLogoutUrl(final String token) {
-        return null;
+        return logoutUrl;
     }
 
     @Override
@@ -93,8 +96,8 @@ public class KakaoProvider implements OAuthProvider {
     }
 
     @Override
-    public HttpEntity<MultiValueMap<String, String>> createLogoutEntity() {
-        return new HttpEntity<>(createTokenHeaders());
+    public HttpEntity<MultiValueMap<String, String>> createLogoutEntity(final String tokenType, final String accessToken) {
+        return new HttpEntity<>(createUserHeaders(tokenType, accessToken));
     }
 
     private HttpHeaders createTokenHeaders() {

--- a/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoProvider.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/support/kakao/KakaoProvider.java
@@ -73,7 +73,7 @@ public class KakaoProvider implements OAuthProvider {
     }
 
     @Override
-    public String generateRevokeToken(final String token) {
+    public String generateLogoutUrl(final String token) {
         return null;
     }
 

--- a/src/test/java/com/dobugs/yologaauthenticationapi/repository/TokenRepositoryTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/repository/TokenRepositoryTest.java
@@ -90,7 +90,6 @@ class TokenRepositoryTest {
         void restore() {
             final HashMap<String, Object> value = new HashMap<>();
             value.put(OAuthToken.KEY_NAME_OF_PROVIDER, Provider.GOOGLE.getName());
-            value.put(OAuthToken.KEY_NAME_OF_ACCESS_TOKEN, null);
             value.put(OAuthToken.KEY_NAME_OF_REFRESH_TOKEN, "beforeRefreshToken");
             operations.putAll(String.valueOf(MEMBER_ID), value);
 
@@ -137,7 +136,6 @@ class TokenRepositoryTest {
         void setUp() {
             final HashMap<String, Object> value = new HashMap<>();
             value.put(OAuthToken.KEY_NAME_OF_PROVIDER, Provider.GOOGLE.getName());
-            value.put(OAuthToken.KEY_NAME_OF_ACCESS_TOKEN, "accessToken");
             value.put(OAuthToken.KEY_NAME_OF_REFRESH_TOKEN, "refreshToken");
 
             final HashOperations<String, Object, Object> operations = redisTemplate.opsForHash();
@@ -150,11 +148,9 @@ class TokenRepositoryTest {
             tokenRepository.delete(MEMBER_ID);
 
             final Boolean hasProvider = operations.hasKey(String.valueOf(MEMBER_ID), OAuthToken.KEY_NAME_OF_PROVIDER);
-            final Boolean hasAccessToken = operations.hasKey(String.valueOf(MEMBER_ID), OAuthToken.KEY_NAME_OF_ACCESS_TOKEN);
             final Boolean hasRefreshToken = operations.hasKey(String.valueOf(MEMBER_ID), OAuthToken.KEY_NAME_OF_REFRESH_TOKEN);
             assertAll(
                 () -> assertThat(hasProvider).isFalse(),
-                () -> assertThat(hasAccessToken).isFalse(),
                 () -> assertThat(hasRefreshToken).isFalse()
             );
         }
@@ -171,7 +167,6 @@ class TokenRepositoryTest {
         void setUp() {
             final HashMap<String, Object> value = new HashMap<>();
             value.put(OAuthToken.KEY_NAME_OF_PROVIDER, Provider.GOOGLE.getName());
-            value.put(OAuthToken.KEY_NAME_OF_ACCESS_TOKEN, null);
             value.put(OAuthToken.KEY_NAME_OF_REFRESH_TOKEN, EXIST_REFRESH_TOKEN);
 
             final HashOperations<String, Object, Object> operations = redisTemplate.opsForHash();
@@ -208,7 +203,6 @@ class TokenRepositoryTest {
         void setUp() {
             final HashMap<String, Object> value = new HashMap<>();
             value.put(OAuthToken.KEY_NAME_OF_PROVIDER, Provider.GOOGLE.getName());
-            value.put(OAuthToken.KEY_NAME_OF_ACCESS_TOKEN, null);
             value.put(OAuthToken.KEY_NAME_OF_REFRESH_TOKEN, EXIST_REFRESH_TOKEN);
 
             final HashOperations<String, Object, Object> operations = redisTemplate.opsForHash();

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/AuthServiceTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/AuthServiceTest.java
@@ -21,6 +21,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.dobugs.yologaauthenticationapi.domain.Member;
+import com.dobugs.yologaauthenticationapi.domain.Provider;
 import com.dobugs.yologaauthenticationapi.repository.MemberRepository;
 import com.dobugs.yologaauthenticationapi.repository.TokenRepository;
 import com.dobugs.yologaauthenticationapi.service.dto.request.OAuthCodeRequest;
@@ -149,18 +150,22 @@ class AuthServiceTest {
     @Nested
     public class reissue {
 
+        private static final Long MEMBER_ID = 0L;
+        private static final String TOKEN_TYPE = "Bearer";
+        private static final String ACCESS_TOKEN = "accessToken";
+        private static final String REFRESH_TOKEN = "refreshToken";
+        private static final int EXPIRES_IN = 1_000;
+
         @DisplayName("Access Token 을 재발급한다")
         @ParameterizedTest
         @ValueSource(strings = {"google", "kakao"})
         void success(final String provider) {
-            final long memberId = 0L;
-            final String refreshToken = "refreshToken";
-            final String serviceToken = createToken(memberId, provider, refreshToken);
+            final String serviceToken = createToken(MEMBER_ID, provider, REFRESH_TOKEN);
 
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(memberId, provider, refreshToken));
-            given(tokenRepository.findRefreshToken(memberId)).willReturn(Optional.of(refreshToken));
-            given(tokenGenerator.setUpExpiration(any())).willReturn(new OAuthTokenDto("accessToken", 1000, "refreshToken", 1000, "Bearer"));
-            given(tokenGenerator.create(eq(memberId), eq(provider), any())).willReturn(new ServiceTokenDto("accessToken", "refreshToken"));
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, provider, TOKEN_TYPE, REFRESH_TOKEN));
+            given(tokenRepository.findRefreshToken(MEMBER_ID)).willReturn(Optional.of(REFRESH_TOKEN));
+            given(tokenGenerator.setUpExpiration(any())).willReturn(new OAuthTokenDto(ACCESS_TOKEN, EXPIRES_IN, REFRESH_TOKEN, EXPIRES_IN, TOKEN_TYPE));
+            given(tokenGenerator.create(eq(MEMBER_ID), eq(provider), any())).willReturn(new ServiceTokenDto(ACCESS_TOKEN, REFRESH_TOKEN));
 
             assertThatCode(() -> authService.reissue(serviceToken))
                 .doesNotThrowAnyException();
@@ -169,12 +174,10 @@ class AuthServiceTest {
         @DisplayName("존재하지 않는 provider 를 요청할 경우 예외가 발생한다")
         @Test
         void notExistProvider() {
-            final long memberId = 0L;
-            final String provider = "notExistProvider";
-            final String refreshToken = "refreshToken";
-            final String serviceToken = createToken(memberId, provider, refreshToken);
+            final String notExistProvider = "notExistProvider";
 
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(memberId, provider, refreshToken));
+            final String serviceToken = createToken(MEMBER_ID, notExistProvider, REFRESH_TOKEN);
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, notExistProvider, TOKEN_TYPE, REFRESH_TOKEN));
 
             assertThatThrownBy(() -> authService.reissue(serviceToken))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -186,10 +189,9 @@ class AuthServiceTest {
         @ValueSource(strings = {"google", "kakao"})
         void notExistMemberId(final String provider) {
             final long notExistMemberId = 0L;
-            final String existRefreshToken = "refreshToken";
-            final String serviceToken = createToken(notExistMemberId, provider, existRefreshToken);
 
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(notExistMemberId, provider, existRefreshToken));
+            final String serviceToken = createToken(notExistMemberId, provider, REFRESH_TOKEN);
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(notExistMemberId, provider, TOKEN_TYPE, REFRESH_TOKEN));
             given(tokenRepository.findRefreshToken(notExistMemberId)).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> authService.reissue(serviceToken))
@@ -201,12 +203,11 @@ class AuthServiceTest {
         @ParameterizedTest
         @ValueSource(strings = {"google", "kakao"})
         void notEqualsRefreshToken(final String provider) {
-            final long existMemberId = 0L;
             final String notExistRefreshToken = "refreshToken";
-            final String serviceToken = createToken(existMemberId, provider, notExistRefreshToken);
+            final String serviceToken = createToken(MEMBER_ID, provider, notExistRefreshToken);
 
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(existMemberId, provider, notExistRefreshToken));
-            given(tokenRepository.findRefreshToken(existMemberId)).willReturn(Optional.of("anotherRefreshToken"));
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, provider, TOKEN_TYPE, notExistRefreshToken));
+            given(tokenRepository.findRefreshToken(MEMBER_ID)).willReturn(Optional.of("anotherRefreshToken"));
 
             assertThatThrownBy(() -> authService.reissue(serviceToken))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -226,16 +227,19 @@ class AuthServiceTest {
     @Nested
     public class logout {
 
+        private static final Long MEMBER_ID = 0L;
+        private static final String PROVIDER = Provider.GOOGLE.getName();
+        private static final String TOKEN_TYPE = "Bearer";
+        private static final String ACCESS_TOKEN = "accessToken";
+        private static final String REFRESH_TOKEN = "refreshToken";
+        private static final int EXPIRES_IN = 1_000;
+
         @DisplayName("로그아웃한다")
         @Test
         void success() {
-            final long memberId = 0L;
-            final String provider = "google";
-            final String refreshToken = "refreshToken";
-            final String serviceToken = createToken(memberId, provider, refreshToken);
-
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(memberId, provider, refreshToken));
-            given(tokenRepository.findRefreshToken(memberId)).willReturn(Optional.of(refreshToken));
+            final String serviceToken = createToken(MEMBER_ID, PROVIDER, REFRESH_TOKEN);
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, TOKEN_TYPE, REFRESH_TOKEN));
+            given(tokenRepository.findRefreshToken(MEMBER_ID)).willReturn(Optional.of(REFRESH_TOKEN));
 
             assertThatCode(() -> authService.logout(serviceToken))
                 .doesNotThrowAnyException();
@@ -245,11 +249,9 @@ class AuthServiceTest {
         @Test
         void notExistMemberId() {
             final long notExistMemberId = 0L;
-            final String provider = "google";
-            final String refreshToken = "refreshToken";
-            final String serviceToken = createToken(notExistMemberId, provider, refreshToken);
 
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(notExistMemberId, provider, refreshToken));
+            final String serviceToken = createToken(notExistMemberId, PROVIDER, REFRESH_TOKEN);
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(notExistMemberId, PROVIDER, TOKEN_TYPE, REFRESH_TOKEN));
             given(tokenRepository.findRefreshToken(notExistMemberId)).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> authService.logout(serviceToken))

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/AuthServiceTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/AuthServiceTest.java
@@ -102,7 +102,7 @@ class AuthServiceTest {
             final OAuthCodeRequest codeRequest = new OAuthCodeRequest("authorizationCode");
 
             given(memberRepository.findByOauthId(any())).willReturn(Optional.of(new Member("oauthId")));
-            given(tokenGenerator.setUpRefreshTokenExpiration(any())).willReturn(new OAuthTokenDto(ACCESS_TOKEN, 1000, REFRESH_TOKEN, 1000, "Bearer"));
+            given(tokenGenerator.setUpExpiration(any())).willReturn(new OAuthTokenDto(ACCESS_TOKEN, 1000, REFRESH_TOKEN, 1000, "Bearer"));
             given(tokenGenerator.create(any(), eq(provider), any())).willReturn(new ServiceTokenDto(ACCESS_TOKEN, REFRESH_TOKEN));
 
             final ServiceTokenResponse response = authService.login(request, codeRequest);
@@ -133,7 +133,7 @@ class AuthServiceTest {
             final OAuthCodeRequest codeRequest = new OAuthCodeRequest("authorizationCode");
 
             given(memberRepository.findByOauthId(any())).willReturn(Optional.empty());
-            given(tokenGenerator.setUpRefreshTokenExpiration(any())).willReturn(new OAuthTokenDto(ACCESS_TOKEN, 1000, REFRESH_TOKEN, 1000, "Bearer"));
+            given(tokenGenerator.setUpExpiration(any())).willReturn(new OAuthTokenDto(ACCESS_TOKEN, 1000, REFRESH_TOKEN, 1000, "Bearer"));
             given(tokenGenerator.create(any(), eq(provider), any())).willReturn(new ServiceTokenDto(ACCESS_TOKEN, REFRESH_TOKEN));
 
             final ServiceTokenResponse response = authService.login(request, codeRequest);
@@ -160,7 +160,7 @@ class AuthServiceTest {
             given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(memberId, provider, refreshToken));
             given(tokenRepository.exist(memberId)).willReturn(true);
             given(tokenRepository.existRefreshToken(memberId, refreshToken)).willReturn(true);
-            given(tokenGenerator.setUpRefreshTokenExpiration(any())).willReturn(new OAuthTokenDto("accessToken", 1000, "refreshToken", 1000, "Bearer"));
+            given(tokenGenerator.setUpExpiration(any())).willReturn(new OAuthTokenDto("accessToken", 1000, "refreshToken", 1000, "Bearer"));
             given(tokenGenerator.create(eq(memberId), eq(provider), any())).willReturn(new ServiceTokenDto("accessToken", "refreshToken"));
 
             assertThatCode(() -> authService.reissue(serviceToken))

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/AuthServiceTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/AuthServiceTest.java
@@ -158,8 +158,7 @@ class AuthServiceTest {
             final String serviceToken = createToken(memberId, provider, refreshToken);
 
             given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(memberId, provider, refreshToken));
-            given(tokenRepository.exist(memberId)).willReturn(true);
-            given(tokenRepository.existRefreshToken(memberId, refreshToken)).willReturn(true);
+            given(tokenRepository.findRefreshToken(memberId)).willReturn(Optional.of(refreshToken));
             given(tokenGenerator.setUpExpiration(any())).willReturn(new OAuthTokenDto("accessToken", 1000, "refreshToken", 1000, "Bearer"));
             given(tokenGenerator.create(eq(memberId), eq(provider), any())).willReturn(new ServiceTokenDto("accessToken", "refreshToken"));
 
@@ -191,7 +190,7 @@ class AuthServiceTest {
             final String serviceToken = createToken(notExistMemberId, provider, existRefreshToken);
 
             given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(notExistMemberId, provider, existRefreshToken));
-            given(tokenRepository.exist(notExistMemberId)).willReturn(false);
+            given(tokenRepository.findRefreshToken(notExistMemberId)).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> authService.reissue(serviceToken))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -207,8 +206,7 @@ class AuthServiceTest {
             final String serviceToken = createToken(existMemberId, provider, notExistRefreshToken);
 
             given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(existMemberId, provider, notExistRefreshToken));
-            given(tokenRepository.exist(existMemberId)).willReturn(true);
-            given(tokenRepository.existRefreshToken(existMemberId, notExistRefreshToken)).willReturn(false);
+            given(tokenRepository.findRefreshToken(existMemberId)).willReturn(Optional.of("anotherRefreshToken"));
 
             assertThatThrownBy(() -> authService.reissue(serviceToken))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -237,7 +235,7 @@ class AuthServiceTest {
             final String serviceToken = createToken(memberId, provider, refreshToken);
 
             given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(memberId, provider, refreshToken));
-            given(tokenRepository.exist(memberId)).willReturn(true);
+            given(tokenRepository.findRefreshToken(memberId)).willReturn(Optional.of(refreshToken));
 
             assertThatCode(() -> authService.logout(serviceToken))
                 .doesNotThrowAnyException();
@@ -252,7 +250,7 @@ class AuthServiceTest {
             final String serviceToken = createToken(notExistMemberId, provider, refreshToken);
 
             given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(notExistMemberId, provider, refreshToken));
-            given(tokenRepository.exist(notExistMemberId)).willReturn(false);
+            given(tokenRepository.findRefreshToken(notExistMemberId)).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> authService.logout(serviceToken))
                 .isInstanceOf(IllegalArgumentException.class)

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/MemberServiceTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/MemberServiceTest.java
@@ -78,6 +78,7 @@ class MemberServiceTest {
 
         private static final Long MEMBER_ID = 0L;
         private static final String PROVIDER = Provider.GOOGLE.getName();
+        private static final String TOKEN_TYPE = "Bearer";
         private static final String ACCESS_TOKEN = "accessToken";
 
         private String serviceToken;
@@ -85,7 +86,7 @@ class MemberServiceTest {
         @BeforeEach
         void setUp() {
             serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, TOKEN_TYPE, ACCESS_TOKEN));
         }
 
         @DisplayName("JWT 를 이용하여 사용자 정보를 조회한다")
@@ -123,6 +124,7 @@ class MemberServiceTest {
 
         private static final Long MEMBER_ID = 0L;
         private static final String PROVIDER = Provider.GOOGLE.getName();
+        private static final String TOKEN_TYPE = "Bearer";
         private static final String ACCESS_TOKEN = "accessToken";
         private static final String NICKNAME = "유콩";
         private static final String PHONE_NUMBER = "010-0000-0000";
@@ -133,7 +135,7 @@ class MemberServiceTest {
         @BeforeEach
         void setUp() {
             serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, TOKEN_TYPE, ACCESS_TOKEN));
 
             request = new MemberUpdateRequest(NICKNAME, PHONE_NUMBER);
         }
@@ -175,6 +177,7 @@ class MemberServiceTest {
 
         private static final Long MEMBER_ID = 0L;
         private static final String PROVIDER = Provider.GOOGLE.getName();
+        private static final String TOKEN_TYPE = "Bearer";
         private static final String ACCESS_TOKEN = "accessToken";
 
         private String serviceToken;
@@ -182,7 +185,7 @@ class MemberServiceTest {
         @BeforeEach
         void setUp() {
             serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, TOKEN_TYPE, ACCESS_TOKEN));
         }
 
         @DisplayName("탈퇴한다")

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/MemberServiceTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/MemberServiceTest.java
@@ -23,8 +23,7 @@ import com.dobugs.yologaauthenticationapi.service.dto.request.MemberUpdateReques
 import com.dobugs.yologaauthenticationapi.service.dto.response.MemberResponse;
 import com.dobugs.yologaauthenticationapi.support.TokenGenerator;
 import com.dobugs.yologaauthenticationapi.support.dto.response.UserTokenResponse;
-
-import io.jsonwebtoken.Jwts;
+import com.dobugs.yologaauthenticationapi.support.fixture.ServiceTokenFixture;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("Member 서비스 테스트")
@@ -85,7 +84,12 @@ class MemberServiceTest {
 
         @BeforeEach
         void setUp() {
-            serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
+            serviceToken = new ServiceTokenFixture.Builder()
+                .memberId(MEMBER_ID)
+                .provider(PROVIDER)
+                .tokenType(TOKEN_TYPE)
+                .token(ACCESS_TOKEN)
+                .build();
             given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, TOKEN_TYPE, ACCESS_TOKEN));
         }
 
@@ -108,14 +112,6 @@ class MemberServiceTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("존재하지 않는 사용자입니다.");
         }
-
-        private String createToken(final Long memberId, final String provider, final String token) {
-            return Jwts.builder()
-                .claim("memberId", memberId)
-                .claim("provider", provider)
-                .claim("token", token)
-                .compact();
-        }
     }
 
     @DisplayName("내 정보 수정 테스트")
@@ -134,7 +130,12 @@ class MemberServiceTest {
 
         @BeforeEach
         void setUp() {
-            serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
+            serviceToken = new ServiceTokenFixture.Builder()
+                .memberId(MEMBER_ID)
+                .provider(PROVIDER)
+                .tokenType(TOKEN_TYPE)
+                .token(ACCESS_TOKEN)
+                .build();
             given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, TOKEN_TYPE, ACCESS_TOKEN));
 
             request = new MemberUpdateRequest(NICKNAME, PHONE_NUMBER);
@@ -161,14 +162,6 @@ class MemberServiceTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("존재하지 않는 사용자입니다.");
         }
-
-        private String createToken(final Long memberId, final String provider, final String token) {
-            return Jwts.builder()
-                .claim("memberId", memberId)
-                .claim("provider", provider)
-                .claim("token", token)
-                .compact();
-        }
     }
 
     @DisplayName("탈퇴하기 테스트")
@@ -184,7 +177,12 @@ class MemberServiceTest {
 
         @BeforeEach
         void setUp() {
-            serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
+            serviceToken = new ServiceTokenFixture.Builder()
+                .memberId(MEMBER_ID)
+                .provider(PROVIDER)
+                .tokenType(TOKEN_TYPE)
+                .token(ACCESS_TOKEN)
+                .build();
             given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, TOKEN_TYPE, ACCESS_TOKEN));
         }
 
@@ -205,14 +203,6 @@ class MemberServiceTest {
             assertThatThrownBy(() -> memberService.delete(serviceToken))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("존재하지 않는 사용자입니다.");
-        }
-
-        private String createToken(final Long memberId, final String provider, final String token) {
-            return Jwts.builder()
-                .claim("memberId", memberId)
-                .claim("provider", provider)
-                .claim("token", token)
-                .compact();
         }
     }
 }

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/ProfileServiceTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/ProfileServiceTest.java
@@ -3,7 +3,6 @@ package com.dobugs.yologaauthenticationapi.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
 
 import java.util.Optional;
 
@@ -16,7 +15,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.web.multipart.MultipartFile;
 
 import com.dobugs.yologaauthenticationapi.domain.Member;
 import com.dobugs.yologaauthenticationapi.domain.Provider;
@@ -28,17 +26,11 @@ import com.dobugs.yologaauthenticationapi.support.FakeStorageGenerator;
 import com.dobugs.yologaauthenticationapi.support.StorageConnector;
 import com.dobugs.yologaauthenticationapi.support.TokenGenerator;
 import com.dobugs.yologaauthenticationapi.support.dto.response.UserTokenResponse;
-
-import io.jsonwebtoken.Jwts;
+import com.dobugs.yologaauthenticationapi.support.fixture.ServiceTokenFixture;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("Profile 서비스 테스트")
 class ProfileServiceTest {
-
-    private static final Long MEMBER_ID = 0L;
-    private static final String PROVIDER = Provider.GOOGLE.getName();
-    private static final String TOKEN_TYPE = "Bearer";
-    private static final String ACCESS_TOKEN = "accessToken";
 
     private ProfileService profileService;
 
@@ -56,18 +48,14 @@ class ProfileServiceTest {
         profileService = new ProfileService(memberRepository, tokenGenerator, fakeS3Connector, new FakeStorageGenerator());
     }
 
-    private String createToken(final Long memberId, final String provider, final String token) {
-        return Jwts.builder()
-            .claim("memberId", memberId)
-            .claim("provider", provider)
-            .claim("token", token)
-            .compact();
-    }
-
     @DisplayName("프로필 수정 테스트")
     @Nested
     public class update {
 
+        private static final Long MEMBER_ID = 0L;
+        private static final String PROVIDER = Provider.GOOGLE.getName();
+        private static final String TOKEN_TYPE = "Bearer";
+        private static final String ACCESS_TOKEN = "accessToken";
         private static final String RESOURCE_NAME = "profile.png";
 
         final MockMultipartFile newProfile = new MockMultipartFile(
@@ -80,7 +68,12 @@ class ProfileServiceTest {
         @DisplayName("프로필을 수정한다")
         @Test
         void success() {
-            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
+            final String serviceToken = new ServiceTokenFixture.Builder()
+                .memberId(MEMBER_ID)
+                .provider(PROVIDER)
+                .tokenType(TOKEN_TYPE)
+                .token(ACCESS_TOKEN)
+                .build();
             given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, TOKEN_TYPE, ACCESS_TOKEN));
 
             final Member member = new Member("oauthId");
@@ -97,7 +90,12 @@ class ProfileServiceTest {
         @DisplayName("기존에 프로필이 없었더라도 프로필 수정에 성공한다")
         @Test
         void profileIsNull() {
-            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
+            final String serviceToken = new ServiceTokenFixture.Builder()
+                .memberId(MEMBER_ID)
+                .provider(PROVIDER)
+                .tokenType(TOKEN_TYPE)
+                .token(ACCESS_TOKEN)
+                .build();
             given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, TOKEN_TYPE, ACCESS_TOKEN));
 
             final Member member = new Member("oauthId");
@@ -118,7 +116,12 @@ class ProfileServiceTest {
                 "new profile content".getBytes()
             );
 
-            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
+            final String serviceToken = new ServiceTokenFixture.Builder()
+                .memberId(MEMBER_ID)
+                .provider(PROVIDER)
+                .tokenType(TOKEN_TYPE)
+                .token(ACCESS_TOKEN)
+                .build();
             given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, TOKEN_TYPE, ACCESS_TOKEN));
 
             assertThatThrownBy(() -> profileService.update(serviceToken, newProfile))
@@ -129,7 +132,12 @@ class ProfileServiceTest {
         @DisplayName("존재하지 않는 사용자의 프로필을 수정하면 예외가 발생한다")
         @Test
         void memberIsNotExist() {
-            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
+            final String serviceToken = new ServiceTokenFixture.Builder()
+                .memberId(MEMBER_ID)
+                .provider(PROVIDER)
+                .tokenType(TOKEN_TYPE)
+                .token(ACCESS_TOKEN)
+                .build();
             given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, TOKEN_TYPE, ACCESS_TOKEN));
             given(memberRepository.findByIdAndArchivedIsTrue(MEMBER_ID)).willReturn(Optional.empty());
 
@@ -143,6 +151,10 @@ class ProfileServiceTest {
     @Nested
     public class init {
 
+        private static final Long MEMBER_ID = 0L;
+        private static final String PROVIDER = Provider.GOOGLE.getName();
+        private static final String TOKEN_TYPE = "Bearer";
+        private static final String ACCESS_TOKEN = "accessToken";
         private static final String RESOURCE_NAME = "profile.png";
 
         private final MockMultipartFile resource = new MockMultipartFile(
@@ -160,7 +172,12 @@ class ProfileServiceTest {
         @DisplayName("프로필을 초기화한다")
         @Test
         void success() {
-            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
+            final String serviceToken = new ServiceTokenFixture.Builder()
+                .memberId(MEMBER_ID)
+                .provider(PROVIDER)
+                .tokenType(TOKEN_TYPE)
+                .token(ACCESS_TOKEN)
+                .build();
             given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, TOKEN_TYPE, ACCESS_TOKEN));
 
             final Member member = new Member("oauthId");
@@ -175,7 +192,12 @@ class ProfileServiceTest {
         @DisplayName("기존에 프로필이 없었더라도 프로필 초기화에 성공한다")
         @Test
         void profileIsNull() {
-            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
+            final String serviceToken = new ServiceTokenFixture.Builder()
+                .memberId(MEMBER_ID)
+                .provider(PROVIDER)
+                .tokenType(TOKEN_TYPE)
+                .token(ACCESS_TOKEN)
+                .build();
             given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, TOKEN_TYPE, ACCESS_TOKEN));
 
             final Member member = new Member("oauthId");
@@ -189,7 +211,12 @@ class ProfileServiceTest {
         @DisplayName("존재하지 않는 사용자의 프로필을 초기화하면 예외가 발생한다")
         @Test
         void memberIsNotExist() {
-            final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
+            final String serviceToken = new ServiceTokenFixture.Builder()
+                .memberId(MEMBER_ID)
+                .provider(PROVIDER)
+                .tokenType(TOKEN_TYPE)
+                .token(ACCESS_TOKEN)
+                .build();
             given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, TOKEN_TYPE, ACCESS_TOKEN));
             given(memberRepository.findByIdAndArchivedIsTrue(MEMBER_ID)).willReturn(Optional.empty());
 

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/ProfileServiceTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/ProfileServiceTest.java
@@ -37,6 +37,7 @@ class ProfileServiceTest {
 
     private static final Long MEMBER_ID = 0L;
     private static final String PROVIDER = Provider.GOOGLE.getName();
+    private static final String TOKEN_TYPE = "Bearer";
     private static final String ACCESS_TOKEN = "accessToken";
 
     private ProfileService profileService;
@@ -80,7 +81,7 @@ class ProfileServiceTest {
         @Test
         void success() {
             final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, TOKEN_TYPE, ACCESS_TOKEN));
 
             final Member member = new Member("oauthId");
             member.updateProfile(new Resource(RESOURCE_NAME, ResourceType.PROFILE, "http://localhost:8080/profile.png"));
@@ -97,7 +98,7 @@ class ProfileServiceTest {
         @Test
         void profileIsNull() {
             final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, TOKEN_TYPE, ACCESS_TOKEN));
 
             final Member member = new Member("oauthId");
             given(memberRepository.findByIdAndArchivedIsTrue(MEMBER_ID)).willReturn(Optional.of(member));
@@ -118,7 +119,7 @@ class ProfileServiceTest {
             );
 
             final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, TOKEN_TYPE, ACCESS_TOKEN));
 
             assertThatThrownBy(() -> profileService.update(serviceToken, newProfile))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -129,7 +130,7 @@ class ProfileServiceTest {
         @Test
         void memberIsNotExist() {
             final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, TOKEN_TYPE, ACCESS_TOKEN));
             given(memberRepository.findByIdAndArchivedIsTrue(MEMBER_ID)).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> profileService.update(serviceToken, newProfile))
@@ -160,7 +161,7 @@ class ProfileServiceTest {
         @Test
         void success() {
             final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, TOKEN_TYPE, ACCESS_TOKEN));
 
             final Member member = new Member("oauthId");
             member.updateProfile(new Resource(RESOURCE_NAME, ResourceType.PROFILE, "http://localhost:8080/profile.png"));
@@ -175,7 +176,7 @@ class ProfileServiceTest {
         @Test
         void profileIsNull() {
             final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, TOKEN_TYPE, ACCESS_TOKEN));
 
             final Member member = new Member("oauthId");
             given(memberRepository.findByIdAndArchivedIsTrue(MEMBER_ID)).willReturn(Optional.of(member));
@@ -189,7 +190,7 @@ class ProfileServiceTest {
         @Test
         void memberIsNotExist() {
             final String serviceToken = createToken(MEMBER_ID, PROVIDER, ACCESS_TOKEN);
-            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, ACCESS_TOKEN));
+            given(tokenGenerator.extract(serviceToken)).willReturn(new UserTokenResponse(MEMBER_ID, PROVIDER, TOKEN_TYPE, ACCESS_TOKEN));
             given(memberRepository.findByIdAndArchivedIsTrue(MEMBER_ID)).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> profileService.init(serviceToken))

--- a/src/test/java/com/dobugs/yologaauthenticationapi/support/FakeOAuthConnector.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/support/FakeOAuthConnector.java
@@ -34,4 +34,9 @@ public class FakeOAuthConnector implements OAuthConnector {
             "Bearer"
         );
     }
+
+    @Override
+    public void logout(final String token) {
+
+    }
 }

--- a/src/test/java/com/dobugs/yologaauthenticationapi/support/FakeOAuthConnector.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/support/FakeOAuthConnector.java
@@ -1,5 +1,6 @@
 package com.dobugs.yologaauthenticationapi.support;
 
+import com.dobugs.yologaauthenticationapi.support.dto.request.OAuthLogoutRequest;
 import com.dobugs.yologaauthenticationapi.support.dto.response.OAuthTokenResponse;
 import com.dobugs.yologaauthenticationapi.support.dto.response.OAuthUserResponse;
 
@@ -36,7 +37,7 @@ public class FakeOAuthConnector implements OAuthConnector {
     }
 
     @Override
-    public void logout(final String token) {
+    public void logout(final OAuthLogoutRequest oAuthLogoutRequest) {
 
     }
 }

--- a/src/test/java/com/dobugs/yologaauthenticationapi/support/FakeOAuthConnector.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/support/FakeOAuthConnector.java
@@ -38,6 +38,5 @@ public class FakeOAuthConnector implements OAuthConnector {
 
     @Override
     public void logout(final OAuthLogoutRequest oAuthLogoutRequest) {
-
     }
 }

--- a/src/test/java/com/dobugs/yologaauthenticationapi/support/FakeOAuthProvider.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/support/FakeOAuthProvider.java
@@ -52,6 +52,11 @@ public class FakeOAuthProvider implements OAuthProvider {
     }
 
     @Override
+    public String generateRevokeToken(final String token) {
+        return null;
+    }
+
+    @Override
     public HttpEntity<MultiValueMap<String, String>> createTokenEntity() {
         return new HttpEntity<>(createTokenHeaders());
     }
@@ -63,6 +68,11 @@ public class FakeOAuthProvider implements OAuthProvider {
 
     @Override
     public HttpEntity<MultiValueMap<String, String>> createAccessTokenEntity() {
+        return new HttpEntity<>(createTokenHeaders());
+    }
+
+    @Override
+    public HttpEntity<MultiValueMap<String, String>> createLogoutEntity() {
         return new HttpEntity<>(createTokenHeaders());
     }
 

--- a/src/test/java/com/dobugs/yologaauthenticationapi/support/FakeOAuthProvider.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/support/FakeOAuthProvider.java
@@ -16,6 +16,7 @@ public class FakeOAuthProvider implements OAuthProvider {
     private static final String AUTH_URL = "authUrl";
     private static final String TOKEN_URL = "tokenUrl";
     private static final String USER_INFO_URL = "userInfoUrl";
+    private static final String LOGOUT_URL = "logoutUrl";
 
     @Override
     public String generateOAuthUrl(final String redirectUrl, final String referrer) {
@@ -53,7 +54,7 @@ public class FakeOAuthProvider implements OAuthProvider {
 
     @Override
     public String generateLogoutUrl(final String token) {
-        return null;
+        return LOGOUT_URL;
     }
 
     @Override

--- a/src/test/java/com/dobugs/yologaauthenticationapi/support/FakeOAuthProvider.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/support/FakeOAuthProvider.java
@@ -72,7 +72,7 @@ public class FakeOAuthProvider implements OAuthProvider {
     }
 
     @Override
-    public HttpEntity<MultiValueMap<String, String>> createLogoutEntity() {
+    public HttpEntity<MultiValueMap<String, String>> createLogoutEntity(final String tokenType, final String token) {
         return new HttpEntity<>(createTokenHeaders());
     }
 

--- a/src/test/java/com/dobugs/yologaauthenticationapi/support/FakeOAuthProvider.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/support/FakeOAuthProvider.java
@@ -52,7 +52,7 @@ public class FakeOAuthProvider implements OAuthProvider {
     }
 
     @Override
-    public String generateRevokeToken(final String token) {
+    public String generateLogoutUrl(final String token) {
         return null;
     }
 

--- a/src/test/java/com/dobugs/yologaauthenticationapi/support/TokenGeneratorTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/support/TokenGeneratorTest.java
@@ -32,13 +32,14 @@ class TokenGeneratorTest {
 
     private static final String SECRET_KEY_VALUE = "secretKey".repeat(10);
     private static final SecretKey SECRET_KEY = Keys.hmacShaKeyFor(SECRET_KEY_VALUE.getBytes(StandardCharsets.UTF_8));
-    private static final int DEFAULT_REFRESH_TOKEN_EXPIRES_IN = 1000;
+    private static final long ACCESS_TOKEN_EXPIRES_IN = 1000;
+    private static final long REFRESH_TOKEN_EXPIRES_IN = 1000;
 
     private TokenGenerator tokenGenerator;
 
     @BeforeEach
     void setUp() {
-        tokenGenerator = new TokenGenerator(SECRET_KEY_VALUE, DEFAULT_REFRESH_TOKEN_EXPIRES_IN);
+        tokenGenerator = new TokenGenerator(SECRET_KEY_VALUE, ACCESS_TOKEN_EXPIRES_IN, REFRESH_TOKEN_EXPIRES_IN);
     }
 
     @DisplayName("token 생성 테스트")
@@ -181,35 +182,26 @@ class TokenGeneratorTest {
         }
     }
 
-    @DisplayName("refresh token 만료 시간 설정 테스트")
+    @DisplayName("만료 시간 설정 테스트")
     @Nested
-    public class setUpRefreshTokenExpiration {
+    public class setUpExpiration {
 
         private static final String ACCESS_TOKEN = "accessToken";
         private static final String REFRESH_TOKEN = "refreshToken";
-        private static final int EXPIRATION = 10_000;
+        private static final int EXPIRATION = 1;
         private static final String TOKEN_TYPE = "Bearer";
 
-        @DisplayName("refresh token 의 만료 시간이 설정되어 있으면 그대로 반환한다")
+        @DisplayName("만료 시간을 설정한다")
         @Test
-        void notSetUp() {
-            final int refreshTokenExpiresIn = 10_000;
-            final OAuthTokenResponse oAuthTokenResponse = new OAuthTokenResponse(ACCESS_TOKEN, EXPIRATION, REFRESH_TOKEN, refreshTokenExpiresIn, TOKEN_TYPE);
+        void success() {
+            final OAuthTokenResponse oAuthTokenResponse = new OAuthTokenResponse(ACCESS_TOKEN, EXPIRATION, REFRESH_TOKEN, EXPIRATION, TOKEN_TYPE);
 
-            final OAuthTokenDto oAuthTokenDto = tokenGenerator.setUpRefreshTokenExpiration(oAuthTokenResponse);
+            final OAuthTokenDto oAuthTokenDto = tokenGenerator.setUpExpiration(oAuthTokenResponse);
 
-            assertThat(oAuthTokenDto.refreshTokenExpiresIn()).isEqualTo(refreshTokenExpiresIn);
-        }
-
-        @DisplayName("refresh token 이 -1 이면 기본 만료 시간으로 설정한다")
-        @Test
-        void setUp() {
-            final int refreshTokenExpiresIn = -1;
-            final OAuthTokenResponse oAuthTokenResponse = new OAuthTokenResponse(ACCESS_TOKEN, EXPIRATION, REFRESH_TOKEN, refreshTokenExpiresIn, TOKEN_TYPE);
-
-            final OAuthTokenDto oAuthTokenDto = tokenGenerator.setUpRefreshTokenExpiration(oAuthTokenResponse);
-
-            assertThat(oAuthTokenDto.refreshTokenExpiresIn()).isEqualTo(DEFAULT_REFRESH_TOKEN_EXPIRES_IN);
+            assertAll(
+                () -> assertThat(oAuthTokenDto.expiresIn()).isEqualTo(ACCESS_TOKEN_EXPIRES_IN),
+                () -> assertThat(oAuthTokenDto.refreshTokenExpiresIn()).isEqualTo(REFRESH_TOKEN_EXPIRES_IN)
+            );
         }
     }
 }

--- a/src/test/java/com/dobugs/yologaauthenticationapi/support/fixture/ServiceTokenFixture.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/support/fixture/ServiceTokenFixture.java
@@ -1,0 +1,120 @@
+package com.dobugs.yologaauthenticationapi.support.fixture;
+
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+
+import io.jsonwebtoken.JwtBuilder;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+
+public class ServiceTokenFixture {
+
+    public static Integer extractMemberId(final String createdToken, final SecretKey secretKey) {
+        return (Integer) Jwts.parserBuilder()
+            .setSigningKey(secretKey)
+            .build()
+            .parseClaimsJws(createdToken)
+            .getBody()
+            .get("memberId");
+    }
+
+    public static String extractToken(final String createdToken, final SecretKey secretKey) {
+        return (String) Jwts.parserBuilder()
+            .setSigningKey(secretKey)
+            .build()
+            .parseClaimsJws(createdToken)
+            .getBody()
+            .get("token");
+    }
+
+    public static String extractProvider(final String createdToken, final SecretKey secretKey) {
+        return (String) Jwts.parserBuilder()
+            .setSigningKey(secretKey)
+            .build()
+            .parseClaimsJws(createdToken)
+            .getBody()
+            .get("provider");
+    }
+
+    public static String extractTokenType(final String createdToken, final SecretKey secretKey) {
+        return (String) Jwts.parserBuilder()
+            .setSigningKey(secretKey)
+            .build()
+            .parseClaimsJws(createdToken)
+            .getBody()
+            .get("tokenType");
+    }
+
+    public static class Builder {
+
+        private Long memberId;
+        private String provider;
+        private String tokenType;
+        private String token;
+        private Date expiration;
+        private SecretKey secretKey;
+        private SignatureAlgorithm algorithm;
+
+        public Builder() {
+        }
+
+        public String build() {
+            final JwtBuilder jwtBuilder = Jwts.builder();
+            if (memberId != null) {
+                jwtBuilder.claim("memberId", memberId);
+            }
+            if (provider != null) {
+                jwtBuilder.claim("provider", provider);
+            }
+            if (tokenType != null) {
+                jwtBuilder.claim("tokenType", tokenType);
+            }
+            if (token != null) {
+                jwtBuilder.claim("token", token);
+            }
+            if (expiration != null) {
+                jwtBuilder.setExpiration(expiration);
+            }
+            if (secretKey != null && algorithm != null) {
+                jwtBuilder.signWith(secretKey, algorithm);
+            }
+            return jwtBuilder.compact();
+        }
+
+        public Builder memberId(final Long memberId) {
+            this.memberId = memberId;
+            return this;
+        }
+
+        public Builder provider(final String provider) {
+            this.provider = provider;
+            return this;
+        }
+
+        public Builder tokenType(final String tokenType) {
+            this.tokenType = tokenType;
+            return this;
+        }
+
+        public Builder token(final String token) {
+            this.token = token;
+            return this;
+        }
+
+        public Builder expiration(final Date expiration) {
+            this.expiration = expiration;
+            return this;
+        }
+
+        public Builder secretKey(final SecretKey secretKey) {
+            this.secretKey = secretKey;
+            return this;
+        }
+
+        public Builder algorithm(final SignatureAlgorithm algorithm) {
+            this.algorithm = algorithm;
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
## *관련 작업 티켓

- https://dobugs.atlassian.net/browse/YOL-180

## *작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- 욜로가 서비스에서 사용하는 토큰에 대한 만료 시간을 통일한다.
  - Access Token : `1시간` / Refresh Token : `1달`
  - 통일 전 만료 시간
    - 구글 : 엑세스 토큰 1시간, 리프레시 토큰 무제한
    - 카카오 : 엑세스 토큰 6시간, 리프레시 토큰 2달
- 기존 로그아웃은 Redis 에 저장된 정보만을 지웠으나, 클라이언트가 직접 외부 서버에게 요청한다면 기능은 동작한다.
- 이를 방지하기 위해 로그아웃 요청 시 외부 서버에서 관리하는 토큰도 로그아웃 시킨다.

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)
