### PR TITLE
feat: 로그인 검증 API 추가

### DIFF
--- a/src/main/java/com/dobugs/yologaauthenticationapi/auth/AuthInterceptor.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/auth/AuthInterceptor.java
@@ -1,4 +1,4 @@
-package com.dobugs.yologaauthenticationapi.config.auth;
+package com.dobugs.yologaauthenticationapi.auth;
 
 import java.lang.annotation.Annotation;
 
@@ -6,8 +6,8 @@ import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 
-import com.dobugs.yologaauthenticationapi.config.dto.response.ServiceToken;
-import com.dobugs.yologaauthenticationapi.config.exception.AuthorizationException;
+import com.dobugs.yologaauthenticationapi.auth.dto.response.ServiceToken;
+import com.dobugs.yologaauthenticationapi.auth.exception.AuthorizationException;
 import com.dobugs.yologaauthenticationapi.repository.TokenRepository;
 
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/dobugs/yologaauthenticationapi/auth/Authorized.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/auth/Authorized.java
@@ -1,4 +1,4 @@
-package com.dobugs.yologaauthenticationapi.config.auth;
+package com.dobugs.yologaauthenticationapi.auth;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -7,5 +7,5 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface ValidatedRefreshToken {
+public @interface Authorized {
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/auth/ExtractAuthorization.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/auth/ExtractAuthorization.java
@@ -1,4 +1,4 @@
-package com.dobugs.yologaauthenticationapi.config.auth;
+package com.dobugs.yologaauthenticationapi.auth;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/main/java/com/dobugs/yologaauthenticationapi/auth/TokenExtractor.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/auth/TokenExtractor.java
@@ -1,4 +1,4 @@
-package com.dobugs.yologaauthenticationapi.config.auth;
+package com.dobugs.yologaauthenticationapi.auth;
 
 import java.nio.charset.StandardCharsets;
 
@@ -7,7 +7,7 @@ import javax.crypto.SecretKey;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import com.dobugs.yologaauthenticationapi.config.dto.response.ServiceToken;
+import com.dobugs.yologaauthenticationapi.auth.dto.response.ServiceToken;
 import com.dobugs.yologaauthenticationapi.domain.JWTPayload;
 
 import io.jsonwebtoken.Claims;

--- a/src/main/java/com/dobugs/yologaauthenticationapi/auth/TokenResolver.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/auth/TokenResolver.java
@@ -1,4 +1,4 @@
-package com.dobugs.yologaauthenticationapi.config.auth;
+package com.dobugs.yologaauthenticationapi.auth;
 
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -9,7 +9,7 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
-import com.dobugs.yologaauthenticationapi.config.exception.AuthorizationException;
+import com.dobugs.yologaauthenticationapi.auth.exception.AuthorizationException;
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/dobugs/yologaauthenticationapi/auth/ValidatedRefreshToken.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/auth/ValidatedRefreshToken.java
@@ -1,4 +1,4 @@
-package com.dobugs.yologaauthenticationapi.config.auth;
+package com.dobugs.yologaauthenticationapi.auth;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -7,5 +7,5 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface Authorized {
+public @interface ValidatedRefreshToken {
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/auth/dto/response/ServiceToken.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/auth/dto/response/ServiceToken.java
@@ -1,4 +1,4 @@
-package com.dobugs.yologaauthenticationapi.config.dto.response;
+package com.dobugs.yologaauthenticationapi.auth.dto.response;
 
 public record ServiceToken(Long memberId, String provider, String tokenType, String token) {
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/auth/exception/AuthorizationException.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/auth/exception/AuthorizationException.java
@@ -1,4 +1,4 @@
-package com.dobugs.yologaauthenticationapi.config.exception;
+package com.dobugs.yologaauthenticationapi.auth.exception;
 
 public class AuthorizationException extends RuntimeException {
 

--- a/src/main/java/com/dobugs/yologaauthenticationapi/config/AuthConfiguration.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/config/AuthConfiguration.java
@@ -1,4 +1,4 @@
-package com.dobugs.yologaauthenticationapi.config.auth;
+package com.dobugs.yologaauthenticationapi.config;
 
 import java.util.List;
 
@@ -7,6 +7,9 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import com.dobugs.yologaauthenticationapi.auth.AuthInterceptor;
+import com.dobugs.yologaauthenticationapi.auth.TokenExtractor;
+import com.dobugs.yologaauthenticationapi.auth.TokenResolver;
 import com.dobugs.yologaauthenticationapi.repository.TokenRepository;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/dobugs/yologaauthenticationapi/config/WebConfiguration.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/config/WebConfiguration.java
@@ -1,5 +1,6 @@
 package com.dobugs.yologaauthenticationapi.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -7,10 +8,20 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebConfiguration implements WebMvcConfigurer {
 
+    @Value("${cors.auth.path}")
+    private String path;
+
+    @Value("${cors.auth.yologa.origin}")
+    private String yologa;
+
     @Override
     public void addCorsMappings(final CorsRegistry registry) {
         registry.addMapping("/**")
             .allowedOrigins("*")
+            .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+            .maxAge(3000);
+        registry.addMapping(path)
+            .allowedOrigins(yologa)
             .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
             .maxAge(3000);
     }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/config/WebConfiguration.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/config/WebConfiguration.java
@@ -16,12 +16,20 @@ public class WebConfiguration implements WebMvcConfigurer {
 
     @Override
     public void addCorsMappings(final CorsRegistry registry) {
-        registry.addMapping("/**")
-            .allowedOrigins("*")
-            .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
-            .maxAge(3000);
+        allowYologaForAuth(registry);
+        allowGlobal(registry);
+    }
+
+    private void allowYologaForAuth(final CorsRegistry registry) {
         registry.addMapping(path)
             .allowedOrigins(yologa)
+            .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+            .maxAge(3000);
+    }
+
+    private void allowGlobal(final CorsRegistry registry) {
+        registry.addMapping("/**")
+            .allowedOrigins("*")
             .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
             .maxAge(3000);
     }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/config/auth/AuthInterceptor.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/config/auth/AuthInterceptor.java
@@ -2,6 +2,7 @@ package com.dobugs.yologaauthenticationapi.config.auth;
 
 import java.lang.annotation.Annotation;
 
+import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 
@@ -21,6 +22,9 @@ public class AuthInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler) {
+        if (CorsUtils.isPreFlightRequest(request)) {
+            return true;
+        }
         if (!hasMethodAnnotation((HandlerMethod) handler, Authorized.class)) {
             return true;
         }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/config/auth/TokenResolver.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/config/auth/TokenResolver.java
@@ -27,7 +27,7 @@ public class TokenResolver implements HandlerMethodArgumentResolver {
     @Override
     public Object resolveArgument(
         final MethodParameter parameter, final ModelAndViewContainer mavContainer,
-        final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) throws Exception {
+        final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) {
         final HttpServletRequest request = (HttpServletRequest)webRequest.getNativeRequest();
         return tokenExtractor.extract(extractAuthorizationHeader(request));
     }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/controller/AuthController.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/controller/AuthController.java
@@ -1,0 +1,22 @@
+package com.dobugs.yologaauthenticationapi.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.dobugs.yologaauthenticationapi.config.auth.Authorized;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+@RestController
+public class AuthController {
+
+    @Authorized
+    @PostMapping("/login")
+    public ResponseEntity<Void> login() {
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/dobugs/yologaauthenticationapi/controller/AuthController.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/controller/AuthController.java
@@ -5,7 +5,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.dobugs.yologaauthenticationapi.config.auth.Authorized;
+import com.dobugs.yologaauthenticationapi.auth.Authorized;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/dobugs/yologaauthenticationapi/controller/MemberController.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/controller/MemberController.java
@@ -6,13 +6,12 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.dobugs.yologaauthenticationapi.config.auth.Authorized;
-import com.dobugs.yologaauthenticationapi.config.auth.ExtractAuthorization;
-import com.dobugs.yologaauthenticationapi.config.dto.response.ServiceToken;
+import com.dobugs.yologaauthenticationapi.auth.Authorized;
+import com.dobugs.yologaauthenticationapi.auth.ExtractAuthorization;
+import com.dobugs.yologaauthenticationapi.auth.dto.response.ServiceToken;
 import com.dobugs.yologaauthenticationapi.service.MemberService;
 import com.dobugs.yologaauthenticationapi.service.dto.request.MemberUpdateRequest;
 import com.dobugs.yologaauthenticationapi.service.dto.response.MemberResponse;

--- a/src/main/java/com/dobugs/yologaauthenticationapi/controller/OAuthController.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/controller/OAuthController.java
@@ -12,7 +12,7 @@ import com.dobugs.yologaauthenticationapi.config.auth.Authorized;
 import com.dobugs.yologaauthenticationapi.config.auth.ExtractAuthorization;
 import com.dobugs.yologaauthenticationapi.config.auth.ValidatedRefreshToken;
 import com.dobugs.yologaauthenticationapi.config.dto.response.ServiceToken;
-import com.dobugs.yologaauthenticationapi.service.AuthService;
+import com.dobugs.yologaauthenticationapi.service.OAuthService;
 import com.dobugs.yologaauthenticationapi.service.dto.request.OAuthCodeRequest;
 import com.dobugs.yologaauthenticationapi.service.dto.request.OAuthRequest;
 import com.dobugs.yologaauthenticationapi.service.dto.response.OAuthLinkResponse;
@@ -23,13 +23,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/oauth2")
 @RestController
-public class AuthController {
+public class OAuthController {
 
-    private final AuthService authService;
+    private final OAuthService oAuthService;
 
     @GetMapping("/login")
     public ResponseEntity<OAuthLinkResponse> generateOAuthUrl(@ModelAttribute final OAuthRequest request) {
-        final OAuthLinkResponse response = authService.generateOAuthUrl(request);
+        final OAuthLinkResponse response = oAuthService.generateOAuthUrl(request);
         return ResponseEntity.ok(response);
     }
 
@@ -38,7 +38,7 @@ public class AuthController {
         @ModelAttribute final OAuthRequest request,
         @RequestBody final OAuthCodeRequest codeRequest
     ) {
-        final ServiceTokenResponse response = authService.login(request, codeRequest);
+        final ServiceTokenResponse response = oAuthService.login(request, codeRequest);
         return ResponseEntity.ok(response);
     }
 
@@ -46,14 +46,14 @@ public class AuthController {
     @ValidatedRefreshToken
     @PostMapping("/reissue")
     public ResponseEntity<ServiceTokenResponse> reissue(@ExtractAuthorization final ServiceToken serviceToken) {
-        final ServiceTokenResponse response = authService.reissue(serviceToken);
+        final ServiceTokenResponse response = oAuthService.reissue(serviceToken);
         return ResponseEntity.ok(response);
     }
 
     @Authorized
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(@ExtractAuthorization final ServiceToken serviceToken) {
-        authService.logout(serviceToken);
+        oAuthService.logout(serviceToken);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/dobugs/yologaauthenticationapi/controller/OAuthController.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/controller/OAuthController.java
@@ -8,10 +8,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.dobugs.yologaauthenticationapi.config.auth.Authorized;
-import com.dobugs.yologaauthenticationapi.config.auth.ExtractAuthorization;
-import com.dobugs.yologaauthenticationapi.config.auth.ValidatedRefreshToken;
-import com.dobugs.yologaauthenticationapi.config.dto.response.ServiceToken;
+import com.dobugs.yologaauthenticationapi.auth.Authorized;
+import com.dobugs.yologaauthenticationapi.auth.ExtractAuthorization;
+import com.dobugs.yologaauthenticationapi.auth.ValidatedRefreshToken;
+import com.dobugs.yologaauthenticationapi.auth.dto.response.ServiceToken;
 import com.dobugs.yologaauthenticationapi.service.OAuthService;
 import com.dobugs.yologaauthenticationapi.service.dto.request.OAuthCodeRequest;
 import com.dobugs.yologaauthenticationapi.service.dto.request.OAuthRequest;

--- a/src/main/java/com/dobugs/yologaauthenticationapi/controller/ProfileController.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/controller/ProfileController.java
@@ -10,9 +10,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.dobugs.yologaauthenticationapi.config.auth.Authorized;
-import com.dobugs.yologaauthenticationapi.config.auth.ExtractAuthorization;
-import com.dobugs.yologaauthenticationapi.config.dto.response.ServiceToken;
+import com.dobugs.yologaauthenticationapi.auth.Authorized;
+import com.dobugs.yologaauthenticationapi.auth.ExtractAuthorization;
+import com.dobugs.yologaauthenticationapi.auth.dto.response.ServiceToken;
 import com.dobugs.yologaauthenticationapi.service.ProfileService;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/dobugs/yologaauthenticationapi/exception/ControllerAdvice.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/exception/ControllerAdvice.java
@@ -4,7 +4,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import com.dobugs.yologaauthenticationapi.config.exception.AuthorizationException;
+import com.dobugs.yologaauthenticationapi.auth.exception.AuthorizationException;
 import com.dobugs.yologaauthenticationapi.exception.dto.response.ExceptionResponse;
 import com.dobugs.yologaauthenticationapi.support.exception.OAuthException;
 

--- a/src/main/java/com/dobugs/yologaauthenticationapi/service/MemberService.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/service/MemberService.java
@@ -3,7 +3,7 @@ package com.dobugs.yologaauthenticationapi.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.dobugs.yologaauthenticationapi.config.dto.response.ServiceToken;
+import com.dobugs.yologaauthenticationapi.auth.dto.response.ServiceToken;
 import com.dobugs.yologaauthenticationapi.domain.Member;
 import com.dobugs.yologaauthenticationapi.domain.Resource;
 import com.dobugs.yologaauthenticationapi.repository.MemberRepository;

--- a/src/main/java/com/dobugs/yologaauthenticationapi/service/OAuthService.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/service/OAuthService.java
@@ -6,7 +6,7 @@ import java.nio.charset.StandardCharsets;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.dobugs.yologaauthenticationapi.config.dto.response.ServiceToken;
+import com.dobugs.yologaauthenticationapi.auth.dto.response.ServiceToken;
 import com.dobugs.yologaauthenticationapi.domain.Member;
 import com.dobugs.yologaauthenticationapi.domain.OAuthToken;
 import com.dobugs.yologaauthenticationapi.domain.Provider;

--- a/src/main/java/com/dobugs/yologaauthenticationapi/service/OAuthService.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/service/OAuthService.java
@@ -29,7 +29,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Transactional
 @Service
-public class AuthService {
+public class OAuthService {
 
     private final OAuthConnector googleConnector;
     private final OAuthConnector kakaoConnector;

--- a/src/main/java/com/dobugs/yologaauthenticationapi/service/ProfileService.java
+++ b/src/main/java/com/dobugs/yologaauthenticationapi/service/ProfileService.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.dobugs.yologaauthenticationapi.config.dto.response.ServiceToken;
+import com.dobugs.yologaauthenticationapi.auth.dto.response.ServiceToken;
 import com.dobugs.yologaauthenticationapi.domain.Member;
 import com.dobugs.yologaauthenticationapi.domain.Resource;
 import com.dobugs.yologaauthenticationapi.domain.ResourceType;

--- a/src/main/resources/application-service-server.yml
+++ b/src/main/resources/application-service-server.yml
@@ -1,0 +1,5 @@
+cors:
+  auth:
+    path: /api/v1/auth/**
+    yologa:
+      origin: https://api.dev.yologa.dobugs.co.kr/

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,7 @@ spring:
     active: dev
   config:
     import:
+      - application-service-server.yml
       - yologa-security/application-oauth2.yml
       - yologa-security/application-jwt.yml
       - yologa-security/application-aws.yml

--- a/src/test/java/com/dobugs/yologaauthenticationapi/config/auth/AuthInterceptorTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/config/auth/AuthInterceptorTest.java
@@ -18,7 +18,8 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import com.dobugs.yologaauthenticationapi.config.dto.response.ServiceToken;
+import com.dobugs.yologaauthenticationapi.auth.TokenExtractor;
+import com.dobugs.yologaauthenticationapi.auth.dto.response.ServiceToken;
 import com.dobugs.yologaauthenticationapi.repository.TokenRepository;
 
 @AutoConfigureMockMvc

--- a/src/test/java/com/dobugs/yologaauthenticationapi/config/auth/FakeController.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/config/auth/FakeController.java
@@ -29,8 +29,8 @@ public class FakeController {
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping("/hasLoginUserAnnotation")
-    public ResponseEntity<Void> hasLoginUserAnnotation(@ExtractAuthorization final ServiceToken serviceToken) {
+    @GetMapping("/hasExtractAuthorizationAnnotation")
+    public ResponseEntity<Void> hasExtractAuthorizationAnnotation(@ExtractAuthorization final ServiceToken serviceToken) {
         return ResponseEntity.ok().build();
     }
 }

--- a/src/test/java/com/dobugs/yologaauthenticationapi/config/auth/FakeController.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/config/auth/FakeController.java
@@ -5,7 +5,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.dobugs.yologaauthenticationapi.config.dto.response.ServiceToken;
+import com.dobugs.yologaauthenticationapi.auth.Authorized;
+import com.dobugs.yologaauthenticationapi.auth.ExtractAuthorization;
+import com.dobugs.yologaauthenticationapi.auth.ValidatedRefreshToken;
+import com.dobugs.yologaauthenticationapi.auth.dto.response.ServiceToken;
 
 @RequestMapping("/api")
 @RestController

--- a/src/test/java/com/dobugs/yologaauthenticationapi/config/auth/TokenExtractorTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/config/auth/TokenExtractorTest.java
@@ -14,7 +14,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import com.dobugs.yologaauthenticationapi.config.dto.response.ServiceToken;
+import com.dobugs.yologaauthenticationapi.auth.TokenExtractor;
+import com.dobugs.yologaauthenticationapi.auth.dto.response.ServiceToken;
 import com.dobugs.yologaauthenticationapi.domain.Provider;
 import com.dobugs.yologaauthenticationapi.support.fixture.ServiceTokenFixture;
 

--- a/src/test/java/com/dobugs/yologaauthenticationapi/config/auth/TokenResolverTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/config/auth/TokenResolverTest.java
@@ -52,9 +52,9 @@ class TokenResolverTest {
 
     @DisplayName("@ExtractAuthorization 어노테이션이 있는 경우 테스트")
     @Nested
-    public class hasLoginUserAnnotation {
+    public class hasExtractAuthorizationAnnotation {
 
-        private static final String URL = BASIC_URL + "/hasLoginUserAnnotation";
+        private static final String URL = BASIC_URL + "/hasExtractAuthorizationAnnotation";
 
         @DisplayName("@ExtractAuthorization 어노테이션이 있을 경우 객체를 추출한다")
         @Test

--- a/src/test/java/com/dobugs/yologaauthenticationapi/config/auth/TokenResolverTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/config/auth/TokenResolverTest.java
@@ -16,7 +16,8 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import com.dobugs.yologaauthenticationapi.config.dto.response.ServiceToken;
+import com.dobugs.yologaauthenticationapi.auth.TokenExtractor;
+import com.dobugs.yologaauthenticationapi.auth.dto.response.ServiceToken;
 import com.dobugs.yologaauthenticationapi.repository.TokenRepository;
 
 @AutoConfigureMockMvc

--- a/src/test/java/com/dobugs/yologaauthenticationapi/controller/AuthControllerTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/controller/AuthControllerTest.java
@@ -20,8 +20,8 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import com.dobugs.yologaauthenticationapi.config.auth.TokenExtractor;
-import com.dobugs.yologaauthenticationapi.config.dto.response.ServiceToken;
+import com.dobugs.yologaauthenticationapi.auth.TokenExtractor;
+import com.dobugs.yologaauthenticationapi.auth.dto.response.ServiceToken;
 import com.dobugs.yologaauthenticationapi.repository.TokenRepository;
 
 @AutoConfigureMockMvc

--- a/src/test/java/com/dobugs/yologaauthenticationapi/controller/AuthControllerTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/controller/AuthControllerTest.java
@@ -1,0 +1,84 @@
+package com.dobugs.yologaauthenticationapi.controller;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.dobugs.yologaauthenticationapi.config.auth.TokenExtractor;
+import com.dobugs.yologaauthenticationapi.config.dto.response.ServiceToken;
+import com.dobugs.yologaauthenticationapi.repository.TokenRepository;
+
+@AutoConfigureMockMvc
+@ExtendWith(MockitoExtension.class)
+@WebMvcTest(AuthController.class)
+@DisplayName("Auth 컨트롤러 테스트")
+class AuthControllerTest {
+
+    private static final String BASIC_URL = "/api/v1/auth";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TokenExtractor tokenExtractor;
+
+    @MockBean
+    private TokenRepository tokenRepository;
+
+    @DisplayName("JWT 검증 테스트")
+    @Nested
+    public class validate {
+
+        private static final String URL = BASIC_URL + "/login";
+
+        @DisplayName("JWT 를 검증한다")
+        @Test
+        void success() throws Exception {
+            given(tokenExtractor.extract(any())).willReturn(new ServiceToken(0L, "google", "Bearer", "token"));
+            given(tokenRepository.findRefreshToken(any())).willReturn(Optional.of("refreshToken"));
+
+            mockMvc.perform(post(URL)
+                    .header("Authorization", "token"))
+                .andExpect(status().isOk())
+            ;
+        }
+
+        @DisplayName("Authorization 헤더에 JWT 가 없을 경우 예외가 발생한다")
+        @Test
+        void notExistAuthorizationHeader() throws Exception {
+            mockMvc.perform(post(URL))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message", containsString("토큰이 필요합니다.")))
+            ;
+        }
+
+        @DisplayName("Redis 에 Refresh Token 이 없을 경우 예외가 발생한다")
+        @Test
+        void notExistRefreshToken() throws Exception {
+            given(tokenExtractor.extract(any())).willReturn(new ServiceToken(0L, "google", "Bearer", "token"));
+            given(tokenRepository.findRefreshToken(any())).willReturn(Optional.empty());
+
+            mockMvc.perform(post(URL)
+                    .header("Authorization", "token"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message", containsString("로그인이 필요한 서비스입니다.")))
+            ;
+        }
+    }
+}

--- a/src/test/java/com/dobugs/yologaauthenticationapi/controller/ControllerTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/controller/ControllerTest.java
@@ -15,8 +15,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
-import com.dobugs.yologaauthenticationapi.config.auth.TokenExtractor;
-import com.dobugs.yologaauthenticationapi.config.dto.response.ServiceToken;
+import com.dobugs.yologaauthenticationapi.auth.TokenExtractor;
+import com.dobugs.yologaauthenticationapi.auth.dto.response.ServiceToken;
 import com.dobugs.yologaauthenticationapi.repository.TokenRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 

--- a/src/test/java/com/dobugs/yologaauthenticationapi/controller/OAuthControllerTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/controller/OAuthControllerTest.java
@@ -18,19 +18,19 @@ import org.springframework.http.MediaType;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
-import com.dobugs.yologaauthenticationapi.service.AuthService;
+import com.dobugs.yologaauthenticationapi.service.OAuthService;
 import com.dobugs.yologaauthenticationapi.service.dto.request.OAuthCodeRequest;
 import com.dobugs.yologaauthenticationapi.service.dto.response.OAuthLinkResponse;
 import com.dobugs.yologaauthenticationapi.service.dto.response.ServiceTokenResponse;
 
-@WebMvcTest(AuthController.class)
-@DisplayName("Auth 컨트롤러 테스트")
-class AuthControllerTest extends ControllerTest {
+@WebMvcTest(OAuthController.class)
+@DisplayName("OAuth 컨트롤러 테스트")
+class OAuthControllerTest extends ControllerTest {
 
     private static final String BASIC_URL = "/api/v1/oauth2";
 
     @MockBean
-    private AuthService authService;
+    private OAuthService oAuthService;
 
     @DisplayName("OAuth 로그인 URL 을 생성한다")
     @Test
@@ -43,7 +43,7 @@ class AuthControllerTest extends ControllerTest {
         params.add("referrer", "referrer");
 
         final OAuthLinkResponse response = new OAuthLinkResponse(redirectUrl);
-        given(authService.generateOAuthUrl(any())).willReturn(response);
+        given(oAuthService.generateOAuthUrl(any())).willReturn(response);
 
         mockMvc.perform(get(BASIC_URL + "/login")
                 .params(params))
@@ -70,7 +70,7 @@ class AuthControllerTest extends ControllerTest {
         final String body = objectMapper.writeValueAsString(request);
 
         final ServiceTokenResponse response = new ServiceTokenResponse("accessToken", "refreshToken");
-        given(authService.login(any(), any())).willReturn(response);
+        given(oAuthService.login(any(), any())).willReturn(response);
 
         mockMvc.perform(post(BASIC_URL + "/login")
                 .params(params)
@@ -92,7 +92,7 @@ class AuthControllerTest extends ControllerTest {
         final String refreshToken = "refreshToken";
 
         final ServiceTokenResponse response = new ServiceTokenResponse(accessToken, refreshToken);
-        given(authService.reissue(any())).willReturn(response);
+        given(oAuthService.reissue(any())).willReturn(response);
 
         mockMvc.perform(post(BASIC_URL + "/reissue")
                 .header("Authorization", refreshToken))

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/MemberServiceTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/MemberServiceTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.dobugs.yologaauthenticationapi.config.dto.response.ServiceToken;
+import com.dobugs.yologaauthenticationapi.auth.dto.response.ServiceToken;
 import com.dobugs.yologaauthenticationapi.domain.Member;
 import com.dobugs.yologaauthenticationapi.domain.Provider;
 import com.dobugs.yologaauthenticationapi.repository.MemberRepository;

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/OAuthServiceTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/OAuthServiceTest.java
@@ -37,13 +37,13 @@ import com.dobugs.yologaauthenticationapi.support.dto.response.ServiceTokenDto;
 import com.dobugs.yologaauthenticationapi.support.fixture.ServiceTokenFixture;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("Auth 서비스 테스트")
-class AuthServiceTest {
+@DisplayName("OAuth 서비스 테스트")
+class OAuthServiceTest {
 
     private static final String REDIRECT_URL = "https://yologa.dobugs.co.kr";
     private static final String REFERRER_URL = "https://yologa.dobugs.co.kr";
 
-    private AuthService authService;
+    private OAuthService oAuthService;
 
     @Mock
     private MemberRepository memberRepository;
@@ -57,7 +57,7 @@ class AuthServiceTest {
     @BeforeEach
     void setUp() {
         final OAuthConnector connector = new FakeOAuthConnector();
-        authService = new AuthService(connector, connector, memberRepository, tokenRepository, tokenGenerator);
+        oAuthService = new OAuthService(connector, connector, memberRepository, tokenRepository, tokenGenerator);
     }
 
     @DisplayName("OAuth URL 생성 테스트")
@@ -70,7 +70,7 @@ class AuthServiceTest {
         void success(final String provider) {
             final OAuthRequest request = new OAuthRequest(provider, REDIRECT_URL, REFERRER_URL);
 
-            final OAuthLinkResponse response = authService.generateOAuthUrl(request);
+            final OAuthLinkResponse response = oAuthService.generateOAuthUrl(request);
 
             assertThat(response.oauthLoginLink()).contains(REDIRECT_URL);
         }
@@ -81,7 +81,7 @@ class AuthServiceTest {
             final String provider = "notExistProvider";
             final OAuthRequest request = new OAuthRequest(provider, REDIRECT_URL, REFERRER_URL);
 
-            assertThatThrownBy(() -> authService.generateOAuthUrl(request))
+            assertThatThrownBy(() -> oAuthService.generateOAuthUrl(request))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("잘못된 provider 입니다.");
         }
@@ -108,7 +108,7 @@ class AuthServiceTest {
             given(tokenGenerator.setUpExpiration(any())).willReturn(new OAuthTokenDto(ACCESS_TOKEN, EXPIRES_IN, REFRESH_TOKEN, EXPIRES_IN, TOKEN_TYPE));
             given(tokenGenerator.create(any(), eq(provider), any())).willReturn(new ServiceTokenDto(ACCESS_TOKEN, REFRESH_TOKEN));
 
-            final ServiceTokenResponse response = authService.login(request, codeRequest);
+            final ServiceTokenResponse response = oAuthService.login(request, codeRequest);
 
             assertAll(
                 () -> assertThat(response.accessToken()).isEqualTo(ACCESS_TOKEN),
@@ -124,7 +124,7 @@ class AuthServiceTest {
             final OAuthRequest request = new OAuthRequest(notExistProvider, REDIRECT_URL, REFERRER_URL);
             final OAuthCodeRequest codeRequest = new OAuthCodeRequest(AUTHORIZATION_CODE);
 
-            assertThatThrownBy(() -> authService.login(request, codeRequest))
+            assertThatThrownBy(() -> oAuthService.login(request, codeRequest))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("잘못된 provider 입니다.");
         }
@@ -140,7 +140,7 @@ class AuthServiceTest {
             given(tokenGenerator.setUpExpiration(any())).willReturn(new OAuthTokenDto(ACCESS_TOKEN, EXPIRES_IN, REFRESH_TOKEN, EXPIRES_IN, TOKEN_TYPE));
             given(tokenGenerator.create(any(), eq(provider), any())).willReturn(new ServiceTokenDto(ACCESS_TOKEN, REFRESH_TOKEN));
 
-            final ServiceTokenResponse response = authService.login(request, codeRequest);
+            final ServiceTokenResponse response = oAuthService.login(request, codeRequest);
 
             assertAll(
                 () -> assertThat(response.accessToken()).isEqualTo(ACCESS_TOKEN),
@@ -173,7 +173,7 @@ class AuthServiceTest {
             given(tokenGenerator.setUpExpiration(any())).willReturn(new OAuthTokenDto(ACCESS_TOKEN, EXPIRES_IN, REFRESH_TOKEN, EXPIRES_IN, TOKEN_TYPE));
             given(tokenGenerator.create(eq(MEMBER_ID), eq(provider), any())).willReturn(new ServiceTokenDto(ACCESS_TOKEN, REFRESH_TOKEN));
 
-            assertThatCode(() -> authService.reissue(serviceToken))
+            assertThatCode(() -> oAuthService.reissue(serviceToken))
                 .doesNotThrowAnyException();
         }
 
@@ -189,7 +189,7 @@ class AuthServiceTest {
                 .token(REFRESH_TOKEN)
                 .build();
 
-            assertThatThrownBy(() -> authService.reissue(serviceToken))
+            assertThatThrownBy(() -> oAuthService.reissue(serviceToken))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("잘못된 provider 입니다.");
         }
@@ -216,7 +216,7 @@ class AuthServiceTest {
                 .build();
             given(tokenRepository.findRefreshToken(MEMBER_ID)).willReturn(Optional.of(ACCESS_TOKEN));
 
-            assertThatCode(() -> authService.logout(serviceToken))
+            assertThatCode(() -> oAuthService.logout(serviceToken))
                 .doesNotThrowAnyException();
         }
 
@@ -233,7 +233,7 @@ class AuthServiceTest {
                 .build();
             given(tokenRepository.findRefreshToken(notExistMemberId)).willReturn(Optional.empty());
 
-            assertThatThrownBy(() -> authService.logout(serviceToken))
+            assertThatThrownBy(() -> oAuthService.logout(serviceToken))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("로그인이 필요합니다.");
         }

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/OAuthServiceTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/OAuthServiceTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.dobugs.yologaauthenticationapi.config.dto.response.ServiceToken;
+import com.dobugs.yologaauthenticationapi.auth.dto.response.ServiceToken;
 import com.dobugs.yologaauthenticationapi.domain.Member;
 import com.dobugs.yologaauthenticationapi.domain.Provider;
 import com.dobugs.yologaauthenticationapi.repository.MemberRepository;

--- a/src/test/java/com/dobugs/yologaauthenticationapi/service/ProfileServiceTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/service/ProfileServiceTest.java
@@ -16,7 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 
-import com.dobugs.yologaauthenticationapi.config.dto.response.ServiceToken;
+import com.dobugs.yologaauthenticationapi.auth.dto.response.ServiceToken;
 import com.dobugs.yologaauthenticationapi.domain.Member;
 import com.dobugs.yologaauthenticationapi.domain.Provider;
 import com.dobugs.yologaauthenticationapi.domain.Resource;

--- a/src/test/java/com/dobugs/yologaauthenticationapi/support/fixture/ServiceTokenFixture.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/support/fixture/ServiceTokenFixture.java
@@ -4,7 +4,7 @@ import java.util.Date;
 
 import javax.crypto.SecretKey;
 
-import com.dobugs.yologaauthenticationapi.config.dto.response.ServiceToken;
+import com.dobugs.yologaauthenticationapi.auth.dto.response.ServiceToken;
 
 import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.Jwts;


### PR DESCRIPTION
## *관련 작업 티켓

- https://dobugs.atlassian.net/browse/YOL-187

## *작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- 욜로가 서버(서비스 서버) 에서 사용자 인증 시 두벅스 서버에게 API 를 호출하여 역할을 위임합니다.
- 그 때 사용할 API 를 구현하였습니다.
- 욜로가 서버에서만 접근 가능하도록 CORS 설정을 하였습니다.

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)
