### PR TITLE
feat: 실행 포트 변경

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,6 +3,7 @@
 APP_NAME=yologa-authentication-api
 JAR_NAME=yologa-authentication-api-0.0.1-SNAPSHOT.jar
 LOG_FILE=application.log
+PORT=8081
 
 # 현재 실행중인 서버가 있으면 잡아서 종료
 CURRENT_PID=$(pgrep -f $APP_NAME)
@@ -21,8 +22,8 @@ cd ~
 cd $APP_NAME
 ./gradlew bootJar
 
-# kill 8080 port
-fuser -k -n tcp 8080
+# kill port
+fuser -k -n tcp ${PORT}
 
 echo ">>>> $APP_NAME execute."
 cd build/libs

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -5,5 +5,3 @@ spring:
     import:
       - application-local-redis.yml
       - application-local-db.yml
-server:
-  port: 8081

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,3 +9,5 @@ spring:
       - yologa-security/application-jwt.yml
       - yologa-security/application-oauth2.yml
       - yologa-security/application-slack.yml
+server:
+  port: 8081


### PR DESCRIPTION
## *관련 작업 티켓

- https://dobugs.atlassian.net/browse/YOL-210

## *작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- 두벅스 서버에서 사용하는 포트를 8080 에서 `8081` 로 변경하였습니다.
- AWS 프리티어에서 제공하는 EC2 사용 시간은 최대 한달에 750 시간입니다.
- 이는 하나의 인스턴스를 한달동안 열어두면 모두 소모되는 시간입니다. (720시간)
- 최대한 서버 구축의 수를 줄이기 위해 포트마다 애플리케이션을 달리 하는 방식으로 변경하였습니다.

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)
