### PR TITLE
refactor: Redis 테스트 시 Embedded Redis 로 대체

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,12 +21,6 @@ jobs:
           distribution: 'zulu'
           java-version: '17'
 
-      - name: Set up Redis
-        uses: shogo82148/actions-setup-redis@v1
-        with:
-          redis-version: '6.x'
-      - run: redis-cli ping
-
       - name: Build with Gradle
         uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
         with:

--- a/src/test/java/com/dobugs/yologaauthenticationapi/repository/EmbeddedRedisConfiguration.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/repository/EmbeddedRedisConfiguration.java
@@ -1,0 +1,28 @@
+package com.dobugs.yologaauthenticationapi.repository;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.TestConfiguration;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import redis.embedded.RedisServer;
+
+@TestConfiguration
+public class EmbeddedRedisConfiguration {
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    private RedisServer server;
+
+    @PostConstruct
+    public void start() {
+        server = new RedisServer(port);
+        server.start();
+    }
+
+    @PreDestroy
+    public void stop() {
+        server.stop();
+    }
+}

--- a/src/test/java/com/dobugs/yologaauthenticationapi/repository/TokenRepositoryTest.java
+++ b/src/test/java/com/dobugs/yologaauthenticationapi/repository/TokenRepositoryTest.java
@@ -14,12 +14,14 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
 import com.dobugs.yologaauthenticationapi.domain.OAuthToken;
 import com.dobugs.yologaauthenticationapi.domain.Provider;
 
+@Import(EmbeddedRedisConfiguration.class)
 @DataRedisTest
 @DisplayName("Token 레포지토리 테스트")
 class TokenRepositoryTest {


### PR DESCRIPTION
## *관련 작업 티켓

- https://dobugs.atlassian.net/browse/YOL-222

## *작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- 깃헙액션 CI 시 MySQL 을 H2 로 대체함에 따라 Redis 도 임베디드 서버를 사용하도록 변경하였습니다.

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)
